### PR TITLE
Compute sparse distance matrix with musly client

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The source code is released under the MPL 2.0 see the file <musly/COPYING>
 ### VERSION 0.2 (under development) ###
 Not released yet.
 
-The second public Musly release. It includes the following API changes and
+The second public Musly release. It includes the following changes and
 additions:
 
 -   `musly_jukebox_addtracks()` requires a fifth argument `generate_ids`: If
@@ -37,6 +37,7 @@ additions:
     and `excerpt_start` controlling the length and position of the audio
     excerpt to be decoded and analyzed instead of the previous `max_seconds`,
     and the libav-based decoder's performance has been improved significantly.
+-   The musly command line client can compute sparse distance matrices (-s).
 
 ### VERSION 0.1 ###
 Released on 30 Jan 2014.
@@ -95,7 +96,7 @@ It should end with `100% tests passed, 0 tests failed`.
 The command line interface is able to:
 
 * Generate M3U playlists for music collections.
-* Output full similarity matrices for more in-depth research of the
+* Output full or sparse similarity matrices for more in-depth research of the
   audio music similarity functions. It uses the music-ir.org MIREX format
   (see <musly/doc/MIREX-DistanceMatrix.md>)
 * Additionally the music similarity features can be ouput in text format

--- a/musly/programoptions.cpp
+++ b/musly/programoptions.cpp
@@ -45,7 +45,7 @@ programoptions::programoptions(int argc, char *argv[],
     opterr = 0;
     while (1) {
 
-        int c = getopt(argc, argv, "v:ihc:a:x:Ee:f:Nn:k:ldm:p:");
+        int c = getopt(argc, argv, "v:ihc:a:x:Ee:f:Nn:k:ldm:s:p:");
         if (c == -1) {
             break;
         }
@@ -71,6 +71,7 @@ programoptions::programoptions(int argc, char *argv[],
         case 'l':
         case 'd':
         case 'm':
+        case 's':
         case 'p':
             if (action.length() != 0) {
                 action = "error";
@@ -159,8 +160,9 @@ cout << "  -i           information about the music similarity library" << endl;
 cout << "  -c COLL      set the file to write the music similarity features and" << endl
      << "               to use for computing similarities." << endl
      << "               DEFAULT: " << default_collection << endl;
-cout << "  -k NUM       set number of similar songs display when computing" << endl
-     << "               playlists ('-p') or evaluating the collection ('-e')." << endl
+cout << "  -k NUM       set number of similar songs per item when computing" << endl
+     << "               playlists ('-p'), sparse distance matrices ('-s')" << endl
+     << "               or when evaluating the collection ('-e')." << endl
      << "               DEFAULT: " << default_k << endl;
 cout << " INITIALIZATION:" << endl;
 cout << "  -n MTH | -N  initialize the collection (set with '-c') using the" << endl
@@ -192,7 +194,12 @@ cout << "  -f NUM       Use an artist filter for the evaluation ('-e'). The " <<
      << "               DEFAULT: -1 (No artist filter)" << endl;
 cout << "  -m FILE      compute the full similarity matrix for the specified" << endl
      << "               collection and write it to FILE. It is written in MIREX" << endl
-     << "               text format (see http://www.music-ir.org/mirex)." << endl;
+     << "               text format (see http://www.music-ir.org/mirex under" << endl
+     << "               Audio Music Similarity and Retrieval, Distance matrix" << endl
+     << "               output files)." << endl;
+cout << "  -s FILE      compute a sparse similarity matrix giving the k nearest" << endl
+     << "               neighbors for each item of the specified collection and" << endl
+     << "               write it to FILE. It is written in MIREX text format." << endl;
 cout << endl;
 //       ======================================================================
 }


### PR DESCRIPTION
This PR adds an option `-s` to the musly command line client so it can compute a sparse similarity matrix that gives the top k hits for each item (equivalent to computing playlists for all files in a collection, but a lot faster than calling musly with `-p` repeatedly because for `-s` the jukebox only needs to be initialized once). The matrix is written in the [MIREX format for sparse similarity matrices](http://www.music-ir.org/mirex/wiki/2014:Audio_Music_Similarity_and_Retrieval#Sparse_Distance_Matrix).
