### PR TITLE
Explicitly register plugins when built statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ else ()
     add_definitions(-DNDEBUG -Wall -g -O3)
 endif () 
 
-option(BUILD_STATIC "Make a static build" OFF)
+option(BUILD_STATIC "Make a static build of libmusly" OFF)
 if (BUILD_STATIC)
     set(BUILD_SHARED_LIBS OFF)
 

--- a/libmusly/CMakeLists.txt
+++ b/libmusly/CMakeLists.txt
@@ -12,6 +12,8 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external")
         external)
     set_source_files_properties(${LIBMUSLY_EXTERNAL}
         PROPERTIES COMPILE_FLAGS "${LIBMUSLY_EXTERNAL_FLAGS}")
+    set_source_files_properties(lib.cpp
+        PROPERTIES COMPILE_FLAGS "-DLIBMUSLY_EXTERNAL")
 endif()
 
 if(EXISTS "${LIBAV_INCLUDE_DIRS}/libavutil/channel_layout.h")
@@ -44,6 +46,11 @@ add_library(libmusly
     mutualproximity.cpp
     lib.cpp
     ${LIBMUSLY_EXTERNAL})
+
+if(BUILD_STATIC)
+    set_target_properties(libmusly
+        PROPERTIES COMPILE_FLAGS "-DBUILD_STATIC")
+endif()
 
 target_link_libraries(libmusly
     ${LIBMUSLY_LIBS}

--- a/libmusly/decoder.h
+++ b/libmusly/decoder.h
@@ -34,13 +34,42 @@ public:
 
 };
 
+/** A macro to facilitating registering a decoder class with musly. This macro
+ * has to be used in the header and class declaration. Call it with the class
+ * name as parameter.
+ */
+#ifndef BUILD_STATIC
 #define MUSLY_DECODER_REGCLASS(classname) \
 private: \
     static const plugin_creator_impl<classname> creator;
+#else
+#define MUSLY_DECODER_REGCLASS(classname)
+#endif
 
+/** A macro to facilitate registering a decoder class with musly. This macro
+ * has to be used in the source file, it has two parameters. Call it with the
+ * name of your class and the priority. The priority value is used if the user
+ * does not request a special musly::decoder when calling \sa
+ * musly_jukebox_poweron(). The method with the highest priority value is used.
+ */
+#ifndef BUILD_STATIC
 #define MUSLY_DECODER_REGIMPL(classname, priority) \
     const plugin_creator_impl<classname> classname::creator(#classname, \
             plugins::DECODER_TYPE, priority);
+#else
+#define MUSLY_DECODER_REGIMPL(classname, priority)
+#endif
+
+/** Alternative form for MUSLY_DECODER_REGIMPL to be used for static builds of
+ * the library. This form has to be placed in global scope in lib.cpp to make
+ * the plugin available in static builds.
+ */
+#ifdef BUILD_STATIC
+#define MUSLY_DECODER_REGSTATIC(classname, priority) \
+    static const musly::plugin_creator_impl<musly::decoders::classname> \
+            create ## _ ## classname (#classname, \
+            musly::plugins::DECODER_TYPE, priority);
+#endif
 
 } /* namespace musly */
 #endif /* MUSLY_DECODER_H_ */

--- a/libmusly/decoders/libav_0_8.h
+++ b/libmusly/decoders/libav_0_8.h
@@ -13,6 +13,10 @@
 #ifndef MUSLY_DECODERS_LIBAV_0_8_H_
 #define MUSLY_DECODERS_LIBAV_0_8_H_
 
+extern "C" {
+    #include <libavcodec/avcodec.h>
+}
+
 #include "decoder.h"
 
 namespace musly {

--- a/libmusly/lib.cpp
+++ b/libmusly/lib.cpp
@@ -19,6 +19,27 @@
 #include "decoder.h"
 #include "method.h"
 
+#ifdef BUILD_STATIC
+// Implementation note: Each plugin is supposed to register itself with
+// the MUSLY_METHOD_REGIMPL or MUSLY_DECODER_REGIMPL call. These calls
+// are usually placed in the plugin's cpp file, and executed when loading
+// the shared library. However, with static linking, these calls are not
+// executed, so the plugins are optimized out. Explicitly registering the
+// plugins here instead ensures the plugins are present in static builds.
+
+#include "methods/mandelellis.h"
+#include "methods/timbre.h"
+#include "decoders/libav_0_8.h"
+
+MUSLY_METHOD_REGSTATIC(mandelellis, 0);
+MUSLY_METHOD_REGSTATIC(timbre, 1);
+MUSLY_DECODER_REGSTATIC(libav_0_8, 0);
+
+#ifdef LIBMUSLY_EXTERNAL
+#include "external/register_static.h"
+#endif
+#endif
+
 
 const char*
 musly_version()

--- a/libmusly/method.h
+++ b/libmusly/method.h
@@ -178,19 +178,38 @@ public:
  * has to be used in the header and class declaration. Call it with the class
  * name as parameter.
  */
+#ifndef BUILD_STATIC
 #define MUSLY_METHOD_REGCLASS(classname) \
 private: \
     static const plugin_creator_impl<classname> creator;
+#else
+#define MUSLY_METHOD_REGCLASS(classname)
+#endif
 
 /** A macro to facilitate registering a method class with musly. This macro has
  * to be used in the source file, it has two parameters. Call it with the name
  * of your class and the priority. The priority value is used if the user
  * does not request a special musly::method when calling \sa
- * musly_jukebox_poweron(). The method with the lowest priority value is used.
+ * musly_jukebox_poweron(). The method with the highest priority value is used.
  */
+#ifndef BUILD_STATIC
 #define MUSLY_METHOD_REGIMPL(classname, priority) \
     const plugin_creator_impl<classname> classname::creator(#classname, \
             plugins::METHOD_TYPE, priority);
+#else
+#define MUSLY_METHOD_REGIMPL(classname, priority)
+#endif
+
+/** Alternative form for MUSLY_METHOD_REGIMPL to be used for static builds of
+ * the library. This form has to be placed in global scope in lib.cpp to make
+ * the plugin available in static builds.
+ */
+#ifdef BUILD_STATIC
+#define MUSLY_METHOD_REGSTATIC(classname, priority) \
+    static const musly::plugin_creator_impl<musly::methods::classname> \
+            create ## _ ## classname (#classname, \
+            musly::plugins::METHOD_TYPE, priority);
+#endif
 
 } /* namespace musly */
 #endif /* MUSLY_METHOD_H_ */


### PR DESCRIPTION
This PR fixes static builds of the library and command line client (with `BUILD_STATIC=1` in cmake). The issue was that the plugin self-registration code was only executed when loading libmusly as a shared library. When compiling it as a static library and statically linking a binary (such as the musly command line client) against it, the linker decided that the plugin classes are unused and did not include them.

To fix that, my original plan was to add a `musly_static_init()` function to the API that has to be called by binaries statically linking against the library to trigger registration of the plugins. But I found that it's enough to just define `static const plugin_creator_impl<...>` variables at the top of `lib.cpp`, which makes it easier for the user.
On a side note, I'm not sure why this is any different than registering them at the top of the `mandelellis.cpp`, `timbre.cpp` and `libav_0_8.cpp` files by initializing the `static const plugin_creator_impl<...>` class members (this is what was done before and is still done for dynamic builds now). Defining `static const` variables in these files instead of the class members did not help for static builds either, the definitions have to be placed in `lib.cpp`.

Note that `BUILD_STATIC=1` only builds the library statically; it still links dynamically against libgcc, libstdc++ and libav. The PR changes the description of `BUILD_STATIC` accordingly, but maybe we should change the build process instead.
