### PR TITLE
Fix namespace for isnan and isinf

### DIFF
--- a/libmusly/gaussianstatistics.cpp
+++ b/libmusly/gaussianstatistics.cpp
@@ -176,7 +176,7 @@ gaussian_statistics::jensenshannon(
         idx_ii += d - i;
     }
 
-    if (isnan(jsd) || isinf(jsd)) {
+    if (std::isnan(jsd) || std::isinf(jsd)) {
         return std::numeric_limits<float>::max();
     }
 
@@ -236,7 +236,7 @@ gaussian_statistics::symmetric_kullbackleibler(
         skld += tmp1 * tmp.mu[i];
     }
 
-    if (isnan(skld) || isinf(skld)) {
+    if (std::isnan(skld) || std::isinf(skld)) {
         return std::numeric_limits<float>::max();
     }
 

--- a/libmusly/mutualproximity.cpp
+++ b/libmusly/mutualproximity.cpp
@@ -165,7 +165,7 @@ mutualproximity::normalize(
         }
 
         float d = sim[i];
-        if (isnan(d)) {
+        if (std::isnan(d)) {
            continue;
         }
 


### PR DESCRIPTION
The project fails to build on Mac OS X with the clang-600.0.57 compiler. Making sure `isnan` and `isinf` are being called from the `std` namespace fixes the issue.