### PR TITLE
Minor command line fixes

### DIFF
--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -683,7 +683,10 @@ main(int argc, char *argv[])
         }
 
         // check if we can initialize a new collection file
-        cf.open("wb");
+        if (!cf.open("wb")) {
+            std::cerr << "Cannot create collection file: " << cf.get_file() << std::endl;
+            return 1;
+        }
 
         std::cout << "Initialized music similarity method: " << mj->method_name
                 << std::endl;

--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -368,7 +368,7 @@ compute_similarity(
         std::vector<musly_track*>& alltracks,
         std::vector<musly_trackid>& alltrackids)
 {
-    int guess_len = (int)(alltracks.size()*0.1);
+    int guess_len = std::max(k, (int)(alltracks.size()*0.1));
     std::vector<musly_trackid> guess_ids(guess_len);
     guess_len = musly_jukebox_guessneighbors(mj, seed,
             guess_ids.data(), guess_len);


### PR DESCRIPTION
This proposes two fixes for the musly command line client example:

1. It wasn't checked if the collection file could be created successfully
2. For collections larger than 9 files but smaller than 10 times the playlist length, playlist computation failed