### PR TITLE
Fix: musly command line client -p with -k larger than collection

### DIFF
--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -372,6 +372,7 @@ compute_similarity(
     std::vector<musly_trackid> guess_ids(guess_len);
     guess_len = musly_jukebox_guessneighbors(mj, seed,
             guess_ids.data(), guess_len);
+    guess_ids.resize(guess_len);
 
     std::vector<similarity_knn> knn_sim;
     std::vector<float> similarities;
@@ -512,6 +513,7 @@ compute_playlist(
     if (track_idx.size() == 0) {
         return "";
     }
+    k = (int)(track_idx.size());
 
     // write playlist
     std::ostringstream pl;


### PR DESCRIPTION
The command line client did not correctly handle the case of computing a playlist for a collection smaller than the requested playlist length (noted in https://github.com/dominikschnitzer/musly/issues/4#issuecomment-122631734).