### PR TITLE
Fix: musly command line client -p or -s for similarity measures without indexing

### DIFF
--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -372,7 +372,7 @@ compute_similarity(
     std::vector<musly_trackid> guess_ids(guess_len);
     guess_len = musly_jukebox_guessneighbors(mj, seed,
             guess_ids.data(), guess_len);
-    guess_ids.resize(guess_len);
+    guess_ids.resize(std::max(guess_len, 0));
 
     std::vector<similarity_knn> knn_sim;
     std::vector<float> similarities;


### PR DESCRIPTION
As reported in https://github.com/dominikschnitzer/musly/commit/1de5a9c1ad571c76bd2e26118a91476e03e6b5b0#commitcomment-14293387, due to a change in #22, the musly command line client crashed with `an instance of 'std::length_error'` for music similarity measures without indexing. (Such measures return `-1` for `musly_jukebox_guessneighbors()`, and this was not guarded against when calling `guess_ids.resize()`.)