### PR TITLE
Support newer libav versions

### DIFF
--- a/libmusly/CMakeLists.txt
+++ b/libmusly/CMakeLists.txt
@@ -17,7 +17,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external")
 endif()
 
 if(EXISTS "${LIBAV_INCLUDE_DIRS}/libavutil/channel_layout.h")
-    set_source_files_properties(decoders/libav_0_8.cpp
+    set_source_files_properties(decoders/libav.cpp
         PROPERTIES COMPILE_FLAGS "-DHAVE_AVUTIL_CHANNEL_LAYOUT")
 endif()
 
@@ -38,7 +38,7 @@ add_library(libmusly
     kissfft/kiss_fftr.c
     methods/mandelellis.cpp
     methods/timbre.cpp
-    decoders/libav_0_8.cpp
+    decoders/libav.cpp
     resampler.cpp
     plugins.cpp
     method.cpp

--- a/libmusly/CMakeLists.txt
+++ b/libmusly/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Process with cmake to create your desired buildfiles.
 
 # (c) 2013-2014, Dominik Schnitzer <dominik@schnitzer.at>
-#          2014, Jan Schlueter <jan.schlueter@ofai.at>
+#     2014-2016, Jan Schlueter <jan.schlueter@ofai.at>
 
 add_subdirectory(
     libresample)

--- a/libmusly/decoders/libav.cpp
+++ b/libmusly/decoders/libav.cpp
@@ -27,7 +27,7 @@ extern "C" {
 
 #include "minilog.h"
 #include "resampler.h"
-#include "libav_0_8.h"
+#include "libav.h"
 
 // We define some macros to be compatible to different libav versions
 // without spreading #if and #else all over the place.
@@ -50,16 +50,16 @@ extern "C" {
 namespace musly {
 namespace decoders {
 
-MUSLY_DECODER_REGIMPL(libav_0_8, 0);
+MUSLY_DECODER_REGIMPL(libav, 0);
 
-libav_0_8::libav_0_8()
+libav::libav()
 {
     av_register_all();
     avcodec_register_all();
 }
 
 int
-libav_0_8::samples_tofloat(
+libav::samples_tofloat(
         void* const out,
         const void* const in,
         const int out_stride,
@@ -116,7 +116,7 @@ void libav_log_callback(void *ptr, int level, const char *fmt, va_list vargs)
 }
 
 std::vector<float>
-libav_0_8::decodeto_22050hz_mono_float(
+libav::decodeto_22050hz_mono_float(
         const std::string& file,
         float excerpt_length,
         float excerpt_start)

--- a/libmusly/decoders/libav.cpp
+++ b/libmusly/decoders/libav.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2014, Dominik Schnitzer <dominik@schnitzer.at>
- *                2014, Jan Schlueter <jan.schlueter@ofai.at>
+ *           2014-2016, Jan Schlueter <jan.schlueter@ofai.at>
  *
  * This file is part of Musly, a program for high performance music
  * similarity computation: http://www.musly.org/.

--- a/libmusly/decoders/libav.h
+++ b/libmusly/decoders/libav.h
@@ -10,8 +10,8 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#ifndef MUSLY_DECODERS_LIBAV_0_8_H_
-#define MUSLY_DECODERS_LIBAV_0_8_H_
+#ifndef MUSLY_DECODERS_LIBAV_H_
+#define MUSLY_DECODERS_LIBAV_H_
 
 extern "C" {
     #include <libavcodec/avcodec.h>
@@ -22,10 +22,10 @@ extern "C" {
 namespace musly {
 namespace decoders {
 
-class libav_0_8 :
+class libav :
     public musly::decoder
 {
-    MUSLY_DECODER_REGCLASS(libav_0_8);
+    MUSLY_DECODER_REGCLASS(libav);
 
 private:
     int
@@ -38,7 +38,7 @@ private:
             int len);
 
 public:
-    libav_0_8();
+    libav();
 
     virtual std::vector<float>
     decodeto_22050hz_mono_float(
@@ -49,4 +49,4 @@ public:
 
 } /* namespace decoders */
 } /* namespace musly */
-#endif /* MUSLY_DECODERS_LIBAV_0_8_H_ */
+#endif /* MUSLY_DECODERS_LIBAV_H_ */

--- a/libmusly/decoders/libav.h
+++ b/libmusly/decoders/libav.h
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2014, Dominik Schnitzer <dominik@schnitzer.at>
- *                2014, Jan Schlueter <jan.schlueter@ofai.at>
+ *           2014-2016, Jan Schlueter <jan.schlueter@ofai.at>
  *
  * This file is part of Musly, a program for high performance music
  * similarity computation: http://www.musly.org/.

--- a/libmusly/lib.cpp
+++ b/libmusly/lib.cpp
@@ -40,11 +40,11 @@ typedef unsigned char uint8_t;
 
 #include "methods/mandelellis.h"
 #include "methods/timbre.h"
-#include "decoders/libav_0_8.h"
+#include "decoders/libav.h"
 
 MUSLY_METHOD_REGSTATIC(mandelellis, 0);
 MUSLY_METHOD_REGSTATIC(timbre, 1);
-MUSLY_DECODER_REGSTATIC(libav_0_8, 0);
+MUSLY_DECODER_REGSTATIC(libav, 0);
 
 #ifdef LIBMUSLY_EXTERNAL
 #include "external/register_static.h"

--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013-2014, Dominik Schnitzer <dominik@schnitzer.at>
- *                2014, Jan Schlueter <jan.schlueter@ofai.at>
+ *           2014-2016, Jan Schlueter <jan.schlueter@ofai.at>
  *
  * This file is part of Musly, a program for high performance music
  * similarity computation: http://www.musly.org/.
@@ -621,7 +621,7 @@ main(int argc, char *argv[])
     std::cout << "Version: " << musly_version() << std::endl;
     std::cout << "(c) 2013-2014, Dominik Schnitzer <dominik@schnitzer.at>"
             << std::endl
-            <<   "         2014, Jan Schlüter <jan.schlueter@ofai.at>"
+            <<   "    2014-2016, Jan Schlüter <jan.schlueter@ofai.at>"
             << std::endl << std::endl;
 
     // Check if we compiled any music similarity methods


### PR DESCRIPTION
The decoder included with musly was written against libav 0.8 (as included in Ubuntu 14.04 LTS). Due to API changes in libav, it is incompatible to recent versions. This PR makes the decoder compatible to the most recent git version, while retaining compatibility to libav 0.8 (as Ubuntu 14.04 LTS is still supported until April 2019).
Closes #25.