### PR TITLE
Allow methods to error out on add_tracks

### DIFF
--- a/libmusly/lib.cpp
+++ b/libmusly/lib.cpp
@@ -192,8 +192,7 @@ musly_jukebox_addtracks(
 {
     if (jukebox && jukebox->method) {
         musly::method* m = reinterpret_cast<musly::method*>(jukebox->method);
-        m->add_tracks(tracks, trackids, length, (generate_ids != 0));
-        return 0;
+        return m->add_tracks(tracks, trackids, length, (generate_ids != 0));
     } else {
         return -1;
     }

--- a/libmusly/method.h
+++ b/libmusly/method.h
@@ -145,7 +145,7 @@ public:
     /**
      *
      */
-    virtual void
+    virtual int
     add_tracks(
             musly_track** tracks,
             musly_trackid* trackids,

--- a/libmusly/methods/mandelellis.cpp
+++ b/libmusly/methods/mandelellis.cpp
@@ -154,7 +154,7 @@ mandelellis::similarity(
     return 0;
 }
 
-void
+int
 mandelellis::add_tracks(
         musly_track** tracks,
         musly_trackid* trackids,
@@ -166,6 +166,7 @@ mandelellis::add_tracks(
     else {
         idpool.add_ids(trackids, length);
     }
+    return 0;
 }
 
 void

--- a/libmusly/methods/mandelellis.h
+++ b/libmusly/methods/mandelellis.h
@@ -80,7 +80,7 @@ public:
             int length,
             float* similarities);
 
-    virtual void
+    virtual int
     add_tracks(
             musly_track** tracks,
             musly_trackid* trackids,

--- a/libmusly/methods/timbre.cpp
+++ b/libmusly/methods/timbre.cpp
@@ -198,12 +198,15 @@ timbre::set_musicstyle(
     return mp.set_normtracks(tracks, length);
 }
 
-void
+int
 timbre::add_tracks(
         musly_track** tracks,
         musly_trackid* trackids,
         int length,
         bool generate_ids) {
+    if (mp.get_normtracks()->size() == 0) {
+        return -1;  // not initialized, cannot add tracks
+    }
     int num_new;
     if (generate_ids) {
         idpool.generate_ids(trackids, length);
@@ -222,6 +225,7 @@ timbre::add_tracks(
 
         mp.set_normfacts(pos + i, sim);
     }
+    return 0;
 }
 
 void

--- a/libmusly/methods/timbre.h
+++ b/libmusly/methods/timbre.h
@@ -87,7 +87,7 @@ public:
             musly_track** tracks,
             int length);
 
-    virtual void
+    virtual int
     add_tracks(
             musly_track** tracks,
             musly_trackid* trackids,


### PR DESCRIPTION
`musly_jukebox_addtracks()` already returns an error code, but it's always `0` if called with a valid jukebox. This PR allows similarity measures to return an error code in their `add_tracks()` method which is passed on to `musly_jukebox_addtracks()`.