### PR TITLE
Support ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Musly
 =====
 
 (c) 2013-2014, Dominik Schnitzer <dominik@schnitzer.at>
-and 2014-2015, Jan Schlüter <jan.schlueter@ofai.at>
+and 2014-2016, Jan Schlüter <jan.schlueter@ofai.at>
 
 Musly is a program and library for high performance audio music similarity
 computation. Musly only uses the audio signal when computing similarities!
@@ -77,8 +77,8 @@ similarity measures visit <http://www.musly.org>.
 
 ## Installation ##
 
-Musly uses the CMake build system, and depends on Eigen 3 and libav 0.8 or
-above.
+Musly uses the CMake build system, and depends on Eigen 3 and ffmpeg or libav
+0.8 or above.
 
 ### Ubuntu prerequisites ###
 
@@ -96,11 +96,15 @@ then run:
 pacman -Sy
 # Install prerequisites
 pacman -S mingw-w64-x86_64-{gcc,cmake-git,pkgconf,eigen3} make wget p7zip
-# Download and install precompiled libav libraries
-wget https://builds.libav.org/windows/release-lgpl/libav-8x6_64-w64-mingw32-11.2.7z
-7z x libav-8x6_64-w64-mingw32-11.2.7z
-cp -a libav-8x6_64-w64-mingw32-11.2/usr/* /usr
-rm -rf libav-8x6_64-w64-mingw32-11.2*
+# Download and install precompiled ffmpeg libraries
+wget https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-latest-win64-dev.7z
+wget https://ffmpeg.zeranoe.com/builds/win64/shared/ffmpeg-latest-win64-shared.7z
+7z x ffmpeg-latest-win64-dev.7z
+7z x ffmpeg-latest-win64-shared.7z
+mv ffmpeg-latest-win64-dev/include/* /usr/include
+mv ffmpeg-latest-win64-dev/lib/* /usr/lib
+mv ffmpeg-latest-win64-shared/bin/* /usr/bin
+rm -rf ffmpeg-latest-win64-*
 # Download and extract latest musly snapshot from git
 wget https://github.com/dominikschnitzer/musly/archive/master.zip
 7z x master.zip

--- a/cmake/FindLibAV.cmake
+++ b/cmake/FindLibAV.cmake
@@ -23,6 +23,7 @@
 #
 # Copyright (c) 2013 Sergiu Dotenco
 # Changed 2015 by Jan Schlüter: https://bitbucket.org/sergiu/libav-cmake/issue/2
+# Changed 2016 by Jan Schlüter: support both ffmpeg and libav
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -117,36 +118,46 @@ ENDIF (DEFINED _LIBAV_MISSING_COMPONENTS AND _LIBAV_CHECK_COMPONENTS)
 
 # Determine library's version
 
-FIND_PROGRAM (LIBAV_AVCONV_EXECUTABLE NAMES avconv
-  HINTS ${LIBAV_ROOT_DIR}
-  PATH_SUFFIXES bin
-  DOC "avconv executable")
+FOREACH(_CMD_NAME ffmpeg avconv)
+  FIND_PROGRAM (LIBAV_EXECUTABLE NAMES ${_CMD_NAME}
+    HINTS ${LIBAV_ROOT_DIR}
+    PATH_SUFFIXES bin
+    DOC "ffmpeg or avconv executable")
 
-IF (LIBAV_AVCONV_EXECUTABLE)
-  EXECUTE_PROCESS (COMMAND ${LIBAV_AVCONV_EXECUTABLE} -version
-    OUTPUT_VARIABLE _LIBAV_AVCONV_OUTPUT ERROR_QUIET)
+  IF (LIBAV_EXECUTABLE)
+    EXECUTE_PROCESS (COMMAND ${LIBAV_EXECUTABLE} -version
+      OUTPUT_VARIABLE _LIBAV_EXECUTABLE_OUTPUT ERROR_QUIET)
 
-  STRING (REGEX REPLACE
-    ".*avconv(\\s+version)?[ \t]+v?([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?).*" "\\2"
-    LIBAV_VERSION "${_LIBAV_AVCONV_OUTPUT}")
-  STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\1"
-    LIBAV_VERSION_MAJOR "${LIBAV_VERSION}")
-  STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\2"
-    LIBAV_VERSION_MINOR "${LIBAV_VERSION}")
+    STRING (REGEX REPLACE
+      ".*${_CMD_NAME}([ \t]+version)?[ \t]+v?([0-9.]*).*" "\\2"
+      LIBAV_VERSION "${_LIBAV_EXECUTABLE_OUTPUT}")
 
-  IF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-    STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\3"
-      LIBAV_VERSION_PATCH "${LIBAV_VERSION}")
-    SET (LIBAV_VERSION_COMPONENTS 3)
-  ELSEIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-    SET (LIBAV_VERSION_COMPONENTS 2)
-  ELSEIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)$")
-    # mostly developer/alpha/beta versions
-    SET (LIBAV_VERSION_COMPONENTS 2)
-    SET (LIBAV_VERSION_MINOR 0)
-    SET (LIBAV_VERSION "${LIBAV_VERSION}.0")
-  ENDIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-ENDIF (LIBAV_AVCONV_EXECUTABLE)
+    IF (LIBAV_VERSION)
+      STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\1"
+        LIBAV_VERSION_MAJOR "${LIBAV_VERSION}")
+      STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\2"
+        LIBAV_VERSION_MINOR "${LIBAV_VERSION}")
+
+      IF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+        STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\3"
+          LIBAV_VERSION_PATCH "${LIBAV_VERSION}")
+        SET (LIBAV_VERSION_COMPONENTS 3)
+      ELSEIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)$")
+        SET (LIBAV_VERSION_COMPONENTS 2)
+      ELSEIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)$")
+        # mostly developer/alpha/beta versions
+        SET (LIBAV_VERSION_COMPONENTS 2)
+        SET (LIBAV_VERSION_MINOR 0)
+        SET (LIBAV_VERSION "${LIBAV_VERSION}.0")
+      ENDIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+    ELSE (LIBAV_VERSION)
+      # clear variable if empty, can trap version check otherwise
+      UNSET (LIBAV_VERSION)
+    ENDIF (LIBAV_VERSION)
+
+    BREAK()
+  ENDIF (LIBAV_EXECUTABLE)
+ENDFOREACH(_CMD_NAME)
 
 IF (WIN32)
   FIND_PROGRAM (LIB_EXECUTABLE NAMES lib


### PR DESCRIPTION
Modifies the cmake files so musly can be built against ffmpeg's libav or libav's libav. Also updates the README to mention ffmpeg support, and use ffmpeg instead of libav in the Windows compilation instructions (for Ubuntu, the existing instructions will use whatever is in the package repository).