### PR TITLE
static build fails unless these link libraries specified

### DIFF
--- a/musly/CMakeLists.txt
+++ b/musly/CMakeLists.txt
@@ -15,6 +15,10 @@ add_executable(musly
     main.cpp)
 
 target_link_libraries(musly
-    libmusly)
+    libmusly
+    avcodec
+    avformat
+    z
+    pthread)
 
 install(TARGETS musly DESTINATION bin)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,10 @@ add_executable(selftest
     main.cpp)
 
 target_link_libraries(selftest
-    libmusly)
+    libmusly
+    avcodec
+    avformat
+    z
+    pthread)
 
 add_test(NAME selftest COMMAND selftest)


### PR DESCRIPTION
if I specify STATIC_BUILD CMake option I need to also add these libraries to make it