### PR TITLE
Fix mixed ffmpeg/avconv support

### DIFF
--- a/cmake/FindLibAV.cmake
+++ b/cmake/FindLibAV.cmake
@@ -118,46 +118,44 @@ ENDIF (DEFINED _LIBAV_MISSING_COMPONENTS AND _LIBAV_CHECK_COMPONENTS)
 
 # Determine library's version
 
-FOREACH(_CMD_NAME ffmpeg avconv)
-  FIND_PROGRAM (LIBAV_EXECUTABLE NAMES ${_CMD_NAME}
-    HINTS ${LIBAV_ROOT_DIR}
-    PATH_SUFFIXES bin
-    DOC "ffmpeg or avconv executable")
+FIND_PROGRAM (LIBAV_EXECUTABLE NAMES ffmpeg avconv
+  HINTS ${LIBAV_ROOT_DIR}
+  PATH_SUFFIXES bin
+  DOC "ffmpeg or avconv executable")
 
-  IF (LIBAV_EXECUTABLE)
-    EXECUTE_PROCESS (COMMAND ${LIBAV_EXECUTABLE} -version
-      OUTPUT_VARIABLE _LIBAV_EXECUTABLE_OUTPUT ERROR_QUIET)
+IF (LIBAV_EXECUTABLE)
+  EXECUTE_PROCESS (COMMAND ${LIBAV_EXECUTABLE} -version
+    OUTPUT_VARIABLE _LIBAV_EXECUTABLE_OUTPUT ERROR_QUIET)
 
-    STRING (REGEX REPLACE
-      ".*${_CMD_NAME}([ \t]+version)?[ \t]+v?([0-9.]*).*" "\\2"
-      LIBAV_VERSION "${_LIBAV_EXECUTABLE_OUTPUT}")
+  GET_FILENAME_COMPONENT(_CMD_NAME ${LIBAV_EXECUTABLE} NAME)
+  STRING (REGEX REPLACE
+    ".*${_CMD_NAME}([ \t]+version)?[ \t]+v?([0-9.]*).*" "\\2"
+    LIBAV_VERSION "${_LIBAV_EXECUTABLE_OUTPUT}")
 
-    IF (LIBAV_VERSION)
-      STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\1"
-        LIBAV_VERSION_MAJOR "${LIBAV_VERSION}")
-      STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\2"
-        LIBAV_VERSION_MINOR "${LIBAV_VERSION}")
+  IF (LIBAV_VERSION)
+    STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\1"
+      LIBAV_VERSION_MAJOR "${LIBAV_VERSION}")
+    STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\2"
+      LIBAV_VERSION_MINOR "${LIBAV_VERSION}")
 
-      IF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-        STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\3"
-          LIBAV_VERSION_PATCH "${LIBAV_VERSION}")
-        SET (LIBAV_VERSION_COMPONENTS 3)
-      ELSEIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)$")
-        SET (LIBAV_VERSION_COMPONENTS 2)
-      ELSEIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)$")
-        # mostly developer/alpha/beta versions
-        SET (LIBAV_VERSION_COMPONENTS 2)
-        SET (LIBAV_VERSION_MINOR 0)
-        SET (LIBAV_VERSION "${LIBAV_VERSION}.0")
-      ENDIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-    ELSE (LIBAV_VERSION)
-      # clear variable if empty, can trap version check otherwise
-      UNSET (LIBAV_VERSION)
-    ENDIF (LIBAV_VERSION)
+    IF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+      STRING (REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.([0-9]+))?" "\\3"
+        LIBAV_VERSION_PATCH "${LIBAV_VERSION}")
+      SET (LIBAV_VERSION_COMPONENTS 3)
+    ELSEIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)$")
+      SET (LIBAV_VERSION_COMPONENTS 2)
+    ELSEIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)$")
+      # mostly developer/alpha/beta versions
+      SET (LIBAV_VERSION_COMPONENTS 2)
+      SET (LIBAV_VERSION_MINOR 0)
+      SET (LIBAV_VERSION "${LIBAV_VERSION}.0")
+    ENDIF ("${LIBAV_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+  ELSE (LIBAV_VERSION)
+    # clear variable if empty, can trap version check otherwise
+    UNSET (LIBAV_VERSION)
+  ENDIF (LIBAV_VERSION)
 
-    BREAK()
-  ENDIF (LIBAV_EXECUTABLE)
-ENDFOREACH(_CMD_NAME)
+ENDIF (LIBAV_EXECUTABLE)
 
 IF (WIN32)
   FIND_PROGRAM (LIB_EXECUTABLE NAMES lib


### PR DESCRIPTION
The loop for checking the ffmpeg or avconv version added in #30 had a flaw: If cmake was invoked a second time, the location of the executable was still cached, so the first iteration of the loop would execute `avconv -version` and try to parse the result as an `ffmpeg` version string, failing the regex. Fixed by using a single `FIND_PROGRAM` call to look for either ffmpeg or avconv, then figure out which of the two was found in order to form the correct regular expression.