### PR TITLE
Refine libavcodec version check to support ffmpeg 3.0

### DIFF
--- a/libmusly/decoders/libav.cpp
+++ b/libmusly/decoders/libav.cpp
@@ -173,8 +173,9 @@ libav::decodeto_22050hz_mono_float(
     AVStream *st = fmtx->streams[audio_stream_idx];
 
     // find a decoder for the stream
-#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 5, 0)
-    // old libav version: stream has a codec context we can use
+#if (LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 14, 0)) || ((LIBAVCODEC_VERSION_MICRO >= 100) && (LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 33, 100)))
+    // old libav version (libavcodec < 57.14 for libav, < 57.33 for ffmpeg):
+    // stream has a codec context we can use
     AVCodecContext *decx = st->codec;
     #define AVCODEC_FREE_CONTEXT(x)
 #else
@@ -195,7 +196,7 @@ libav::decodeto_22050hz_mono_float(
         avformat_close_input(&fmtx);
         return std::vector<float>(0);
     }
-    #if LIBAVFORMAT_VERSION_MICRO >= 100
+    #if LIBAVCODEC_VERSION_MICRO >= 100
     // only available in ffmpeg
     av_codec_set_pkt_timebase(decx, st->time_base);
     #endif


### PR DESCRIPTION
Changes the conditional compilation of the libav decoder to support the libavcodec version shipped with ffmpeg 3.0. Fixes #33. Tested to compile fine with ffmpeg 3.0.6 (which did not work before), and to still compile with older and more recent versions. Thanks @grray for the report!