### PR TITLE
Have timbre similarity return error if mututal proximity fails

### DIFF
--- a/libmusly/methods/timbre.cpp
+++ b/libmusly/methods/timbre.cpp
@@ -181,10 +181,10 @@ timbre::similarity(
         other_positions[i] = idpool.position_of(trackids[i]);
     }
     // - call mp.normalize with these positions
-    mp.normalize(seed_position, other_positions, length, similarities);
+    int res = mp.normalize(seed_position, other_positions, length, similarities);
     delete[] other_positions;
 
-    return 0;
+    return res;
 }
 
 int

--- a/libmusly/mutualproximity.cpp
+++ b/libmusly/mutualproximity.cpp
@@ -149,14 +149,14 @@ mutualproximity::normalize(
         int length,
         float* sim)
 {
-    if (seed_position >= (int)norm_facts.size()) {
+    if (seed_position < 0 || seed_position >= (int)norm_facts.size()) {
         return -1;
     }
     float seed_mu = norm_facts[seed_position].mu;
     float seed_std = norm_facts[seed_position].std;
     for (int i = 0; i < length; i++) {
         int pos = other_positions[i];
-        if (pos >= (int)norm_facts.size()) {
+        if (pos < 0 || pos >= (int)norm_facts.size()) {
             return -1;
         }
         if (pos == seed_position) {


### PR DESCRIPTION
For the `timbre` similarity measure, `musly_jukebox_similarity()` requires the correct track ids to be given so it can perform the mutual proximity scaling. This PR ensures an error code is returned if the track ids are missing or invalid.