### PR TITLE
Fix issue 41: extra / in file paths when adding tracks

### DIFF
--- a/musly/fileiterator.cpp
+++ b/musly/fileiterator.cpp
@@ -30,6 +30,11 @@ fileiterator::fileiterator(const std::string& path,
 {
     current_dir = path;
 
+    // Remove eventual trailing '/' in path (it will we added later)
+    while (current_dir.length() > 1 and current_dir.back() == '/') {
+        current_dir = current_dir.substr(0,current_dir.size()-1);  
+    }
+
     // set scan extension
     if (extension.length() > 0) {
         search_ext = "." + extension;


### PR DESCRIPTION
When using tab autocompletion for path/to/music/files, usually an extra "/" is added at the end, which corrupts the path of files in collection.
I edited `main.cpp` in the action ` -a` to remove the extra "/" if it exists.