### PR TITLE
Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,20 @@ matrix:
           dist: bionic
           compiler: clang
 
+        - name: "MSVC (19.16) on VS 2017/Windows 1809"
+          os: windows
+          before_install:
+              - curl -O https://ffmpeg.zeranoe.com/builds/win32/dev/ffmpeg-4.2-win32-dev.zip
+              - unzip ffmpeg-4.2-win32-dev.zip
+              - curl -O https://bitbucket.org/eigen/eigen/get/3.3.7.zip
+              - unzip 3.3.7.zip
+              - export CARGS="-DEIGEN3_INCLUDE_DIR=$(pwd)/eigen-eigen-323c052e1731 -DLIBAV_ROOT_DIR=$(pwd)/ffmpeg-4.2-win32-dev"
+
 script:
     - mkdir -p build
     - cd build
-    - cmake ..
-    - make -j
+    - cmake -DBUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release ${CARGS} ..
+    - cmake --build . --config Release
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ matrix:
         - name: "MSVC (19.16) on VS 2017/Windows 1809"
           os: windows
           before_install:
-              - curl -O https://ffmpeg.zeranoe.com/builds/win32/dev/ffmpeg-4.2-win32-dev.zip
-              - unzip ffmpeg-4.2-win32-dev.zip
+              - curl -O https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-4.2-win64-dev.zip
+              - unzip ffmpeg-4.2-win64-dev.zip
               - curl -O https://bitbucket.org/eigen/eigen/get/3.3.7.zip
               - unzip 3.3.7.zip
-              - export CARGS="-DEIGEN3_INCLUDE_DIR=$(pwd)/eigen-eigen-323c052e1731 -DLIBAV_ROOT_DIR=$(pwd)/ffmpeg-4.2-win32-dev"
+              - export CARGS="-DCMAKE_GENERATOR_PLATFORM=x64 -DEIGEN3_INCLUDE_DIR=$(pwd)/eigen-eigen-323c052e1731 -DLIBAV_ROOT_DIR=$(pwd)/ffmpeg-4.2-win64-dev"
 
 script:
     - mkdir -p build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,12 @@ if (MSVC)
     set(PREFER_STATIC ON)
 else()
     # lots of warnings and all warnings as errors
-    add_compile_options(-Wall -Wextra -pedantic)
+    add_compile_options(-Wall
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+        $<$<COMPILE_LANGUAGE:CXX>:-pedantic>)
     # On Unix, hide symbols by default (see https://gcc.gnu.org/wiki/Visibility)
-    add_compile_options(-fvisibility=hidden -fvisibility-inlines-hidden)
+    add_compile_options(-fvisibility=hidden
+        $<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>)
 
     set(PREFER_STATIC OFF)
 endif()
@@ -51,6 +54,8 @@ if (BUILD_STATIC)
 else ()
     set(BUILD_SHARED_LIBS ON)
 endif ()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_TEST "Build selftest executable" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (MSVC)
     set(PREFER_STATIC ON)
 else()
     # lots of warnings and all warnings as errors
-    add_compile_options(-Wall
+    add_compile_options(-Wall -Werror
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
         $<$<COMPILE_LANGUAGE:CXX>:-pedantic>)
     # On Unix, hide symbols by default (see https://gcc.gnu.org/wiki/Visibility)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,10 @@ include_directories(
     "${PROJECT_BINARY_DIR}"
     "${PROJECT_SOURCE_DIR}/include")
 
-add_subdirectory(libmusly) 
-add_subdirectory(musly) 
-add_subdirectory(include) 
+add_subdirectory(external)
+add_subdirectory(libmusly)
+add_subdirectory(musly)
+add_subdirectory(include)
 if (BUILD_TEST)
     enable_testing()
     add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,28 +4,44 @@
 # (c) 2013-2014, Dominik Schnitzer <dominik@schnitzer.at>
 #          2014, Jan Schlueter <jan.schlueter@ofai.at>
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(musly)
 set(MUSLY_VERSION "0.2")
 add_definitions(-DMUSLY_VERSION="${MUSLY_VERSION}")
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_definitions(-Wall -g)
-elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
-    add_definitions(-DNDEBUG -O3)
-else ()
-    add_definitions(-DNDEBUG -Wall -g -O3)
-endif ()
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-# On Unix, hide symbols by default (see https://gcc.gnu.org/wiki/Visibility)
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
-    OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
-endif () 
+if (MSVC)
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.14)
+        add_compile_options(/experimental:external /external:W0)
+        set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "/external:I")
+        set(CMAKE_INCLUDE_SYSTEM_FLAG_C "/external:I")
+    endif()
 
-option(BUILD_STATIC "Make a static build of libmusly" OFF)
+    # warning level 4 and all warnings as errors
+    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    endif()
+    if(CMAKE_C_FLAGS MATCHES "/W[0-4]")
+        string(REGEX REPLACE "/W[0-4]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    endif()
+    add_compile_options(/WX)
+
+    add_compile_definitions(NOMINMAX _USE_MATH_DEFINES)
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+
+    set(PREFER_STATIC ON)
+else()
+    # lots of warnings and all warnings as errors
+    add_compile_options(-Wall -Wextra -pedantic)
+    # On Unix, hide symbols by default (see https://gcc.gnu.org/wiki/Visibility)
+    add_compile_options(-fvisibility=hidden -fvisibility-inlines-hidden)
+
+    set(PREFER_STATIC OFF)
+endif()
+
+option(BUILD_STATIC "Make a static build of libmusly" PREFER_STATIC)
 if (BUILD_STATIC)
     set(BUILD_SHARED_LIBS OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ add_definitions(-DMUSLY_VERSION="${MUSLY_VERSION}")
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if (MSVC)
+    # Ninja uses those flags on Windows, MSBuild ignores them
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.14)
         add_compile_options(/experimental:external /external:W0)
         set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "/external:I")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,9 @@
+# CMake buildfile generator file.
+# Process with cmake to create your desired buildfiles.
+
+# (c) 2019, Dominik Schnitzer <dominik@schnitzer.at>
+
+if(WIN32)
+    add_subdirectory(dirent)
+    add_subdirectory(getopt)
+endif()

--- a/external/dirent/CMakeLists.txt
+++ b/external/dirent/CMakeLists.txt
@@ -1,0 +1,8 @@
+# CMake buildfile generator file.
+# Process with cmake to create your desired buildfiles.
+
+# (c) 2019, Dominik Schnitzer <dominik@schnitzer.at>
+
+add_library(dirent_windows INTERFACE)
+target_include_directories(dirent_windows INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR})

--- a/external/dirent/dirent.h
+++ b/external/dirent/dirent.h
@@ -1,0 +1,1160 @@
+/*
+ * Dirent interface for Microsoft Visual Studio
+ *
+ * Copyright (C) 1998-2019 Toni Ronkko
+ * This file is part of dirent.  Dirent may be freely distributed
+ * under the MIT license.  For all details and documentation, see
+ * https://github.com/tronkko/dirent
+ */
+#ifndef DIRENT_H
+#define DIRENT_H
+
+/* Hide warnings about unreferenced local functions */
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wunused-function"
+#elif defined(_MSC_VER)
+#   pragma warning(disable:4505)
+#elif defined(__GNUC__)
+#   pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
+/*
+ * Include windows.h without Windows Sockets 1.1 to prevent conflicts with
+ * Windows Sockets 2.0.
+ */
+#ifndef WIN32_LEAN_AND_MEAN
+#   define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <wchar.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+/* Indicates that d_type field is available in dirent structure */
+#define _DIRENT_HAVE_D_TYPE
+
+/* Indicates that d_namlen field is available in dirent structure */
+#define _DIRENT_HAVE_D_NAMLEN
+
+/* Entries missing from MSVC 6.0 */
+#if !defined(FILE_ATTRIBUTE_DEVICE)
+#   define FILE_ATTRIBUTE_DEVICE 0x40
+#endif
+
+/* File type and permission flags for stat(), general mask */
+#if !defined(S_IFMT)
+#   define S_IFMT _S_IFMT
+#endif
+
+/* Directory bit */
+#if !defined(S_IFDIR)
+#   define S_IFDIR _S_IFDIR
+#endif
+
+/* Character device bit */
+#if !defined(S_IFCHR)
+#   define S_IFCHR _S_IFCHR
+#endif
+
+/* Pipe bit */
+#if !defined(S_IFFIFO)
+#   define S_IFFIFO _S_IFFIFO
+#endif
+
+/* Regular file bit */
+#if !defined(S_IFREG)
+#   define S_IFREG _S_IFREG
+#endif
+
+/* Read permission */
+#if !defined(S_IREAD)
+#   define S_IREAD _S_IREAD
+#endif
+
+/* Write permission */
+#if !defined(S_IWRITE)
+#   define S_IWRITE _S_IWRITE
+#endif
+
+/* Execute permission */
+#if !defined(S_IEXEC)
+#   define S_IEXEC _S_IEXEC
+#endif
+
+/* Pipe */
+#if !defined(S_IFIFO)
+#   define S_IFIFO _S_IFIFO
+#endif
+
+/* Block device */
+#if !defined(S_IFBLK)
+#   define S_IFBLK 0
+#endif
+
+/* Link */
+#if !defined(S_IFLNK)
+#   define S_IFLNK 0
+#endif
+
+/* Socket */
+#if !defined(S_IFSOCK)
+#   define S_IFSOCK 0
+#endif
+
+/* Read user permission */
+#if !defined(S_IRUSR)
+#   define S_IRUSR S_IREAD
+#endif
+
+/* Write user permission */
+#if !defined(S_IWUSR)
+#   define S_IWUSR S_IWRITE
+#endif
+
+/* Execute user permission */
+#if !defined(S_IXUSR)
+#   define S_IXUSR 0
+#endif
+
+/* Read group permission */
+#if !defined(S_IRGRP)
+#   define S_IRGRP 0
+#endif
+
+/* Write group permission */
+#if !defined(S_IWGRP)
+#   define S_IWGRP 0
+#endif
+
+/* Execute group permission */
+#if !defined(S_IXGRP)
+#   define S_IXGRP 0
+#endif
+
+/* Read others permission */
+#if !defined(S_IROTH)
+#   define S_IROTH 0
+#endif
+
+/* Write others permission */
+#if !defined(S_IWOTH)
+#   define S_IWOTH 0
+#endif
+
+/* Execute others permission */
+#if !defined(S_IXOTH)
+#   define S_IXOTH 0
+#endif
+
+/* Maximum length of file name */
+#if !defined(PATH_MAX)
+#   define PATH_MAX MAX_PATH
+#endif
+#if !defined(FILENAME_MAX)
+#   define FILENAME_MAX MAX_PATH
+#endif
+#if !defined(NAME_MAX)
+#   define NAME_MAX FILENAME_MAX
+#endif
+
+/* File type flags for d_type */
+#define DT_UNKNOWN 0
+#define DT_REG S_IFREG
+#define DT_DIR S_IFDIR
+#define DT_FIFO S_IFIFO
+#define DT_SOCK S_IFSOCK
+#define DT_CHR S_IFCHR
+#define DT_BLK S_IFBLK
+#define DT_LNK S_IFLNK
+
+/* Macros for converting between st_mode and d_type */
+#define IFTODT(mode) ((mode) & S_IFMT)
+#define DTTOIF(type) (type)
+
+/*
+ * File type macros.  Note that block devices, sockets and links cannot be
+ * distinguished on Windows and the macros S_ISBLK, S_ISSOCK and S_ISLNK are
+ * only defined for compatibility.  These macros should always return false
+ * on Windows.
+ */
+#if !defined(S_ISFIFO)
+#   define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#endif
+#if !defined(S_ISDIR)
+#   define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+#if !defined(S_ISREG)
+#   define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+#if !defined(S_ISLNK)
+#   define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#endif
+#if !defined(S_ISSOCK)
+#   define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
+#endif
+#if !defined(S_ISCHR)
+#   define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#endif
+#if !defined(S_ISBLK)
+#   define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#endif
+
+/* Return the exact length of the file name without zero terminator */
+#define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
+
+/* Return the maximum size of a file name */
+#define _D_ALLOC_NAMLEN(p) ((PATH_MAX)+1)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Wide-character version */
+struct _wdirent {
+    /* Always zero */
+    long d_ino;
+
+    /* File position within stream */
+    long d_off;
+
+    /* Structure size */
+    unsigned short d_reclen;
+
+    /* Length of name without \0 */
+    size_t d_namlen;
+
+    /* File type */
+    int d_type;
+
+    /* File name */
+    wchar_t d_name[PATH_MAX+1];
+};
+typedef struct _wdirent _wdirent;
+
+struct _WDIR {
+    /* Current directory entry */
+    struct _wdirent ent;
+
+    /* Private file data */
+    WIN32_FIND_DATAW data;
+
+    /* True if data is valid */
+    int cached;
+
+    /* Win32 search handle */
+    HANDLE handle;
+
+    /* Initial directory name */
+    wchar_t *patt;
+};
+typedef struct _WDIR _WDIR;
+
+/* Multi-byte character version */
+struct dirent {
+    /* Always zero */
+    long d_ino;
+
+    /* File position within stream */
+    long d_off;
+
+    /* Structure size */
+    unsigned short d_reclen;
+
+    /* Length of name without \0 */
+    size_t d_namlen;
+
+    /* File type */
+    int d_type;
+
+    /* File name */
+    char d_name[PATH_MAX+1];
+};
+typedef struct dirent dirent;
+
+struct DIR {
+    struct dirent ent;
+    struct _WDIR *wdirp;
+};
+typedef struct DIR DIR;
+
+
+/* Dirent functions */
+static DIR *opendir (const char *dirname);
+static _WDIR *_wopendir (const wchar_t *dirname);
+
+static struct dirent *readdir (DIR *dirp);
+static struct _wdirent *_wreaddir (_WDIR *dirp);
+
+static int readdir_r(
+    DIR *dirp, struct dirent *entry, struct dirent **result);
+static int _wreaddir_r(
+    _WDIR *dirp, struct _wdirent *entry, struct _wdirent **result);
+
+static int closedir (DIR *dirp);
+static int _wclosedir (_WDIR *dirp);
+
+static void rewinddir (DIR* dirp);
+static void _wrewinddir (_WDIR* dirp);
+
+static int scandir (const char *dirname, struct dirent ***namelist,
+    int (*filter)(const struct dirent*),
+    int (*compare)(const struct dirent**, const struct dirent**));
+
+static int alphasort (const struct dirent **a, const struct dirent **b);
+
+static int versionsort (const struct dirent **a, const struct dirent **b);
+
+
+/* For compatibility with Symbian */
+#define wdirent _wdirent
+#define WDIR _WDIR
+#define wopendir _wopendir
+#define wreaddir _wreaddir
+#define wclosedir _wclosedir
+#define wrewinddir _wrewinddir
+
+
+/* Internal utility functions */
+static WIN32_FIND_DATAW *dirent_first (_WDIR *dirp);
+static WIN32_FIND_DATAW *dirent_next (_WDIR *dirp);
+
+static int dirent_mbstowcs_s(
+    size_t *pReturnValue,
+    wchar_t *wcstr,
+    size_t sizeInWords,
+    const char *mbstr,
+    size_t count);
+
+static int dirent_wcstombs_s(
+    size_t *pReturnValue,
+    char *mbstr,
+    size_t sizeInBytes,
+    const wchar_t *wcstr,
+    size_t count);
+
+static void dirent_set_errno (int error);
+
+
+/*
+ * Open directory stream DIRNAME for read and return a pointer to the
+ * internal working area that is used to retrieve individual directory
+ * entries.
+ */
+static _WDIR*
+_wopendir(
+    const wchar_t *dirname)
+{
+    _WDIR *dirp;
+    DWORD n;
+    wchar_t *p;
+
+    /* Must have directory name */
+    if (dirname == NULL  ||  dirname[0] == '\0') {
+        dirent_set_errno (ENOENT);
+        return NULL;
+    }
+
+    /* Allocate new _WDIR structure */
+    dirp = (_WDIR*) malloc (sizeof (struct _WDIR));
+    if (!dirp) {
+        return NULL;
+    }
+
+    /* Reset _WDIR structure */
+    dirp->handle = INVALID_HANDLE_VALUE;
+    dirp->patt = NULL;
+    dirp->cached = 0;
+
+    /*
+     * Compute the length of full path plus zero terminator
+     *
+     * Note that on WinRT there's no way to convert relative paths
+     * into absolute paths, so just assume it is an absolute path.
+     */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    /* Desktop */
+    n = GetFullPathNameW (dirname, 0, NULL, NULL);
+#else
+    /* WinRT */
+    n = wcslen (dirname);
+#endif
+
+    /* Allocate room for absolute directory name and search pattern */
+    dirp->patt = (wchar_t*) malloc (sizeof (wchar_t) * n + 16);
+    if (dirp->patt == NULL) {
+        goto exit_closedir;
+    }
+
+    /*
+     * Convert relative directory name to an absolute one.  This
+     * allows rewinddir() to function correctly even when current
+     * working directory is changed between opendir() and rewinddir().
+     *
+     * Note that on WinRT there's no way to convert relative paths
+     * into absolute paths, so just assume it is an absolute path.
+     */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    /* Desktop */
+    n = GetFullPathNameW (dirname, n, dirp->patt, NULL);
+    if (n <= 0) {
+        goto exit_closedir;
+    }
+#else
+    /* WinRT */
+    wcsncpy_s (dirp->patt, n+1, dirname, n);
+#endif
+
+    /* Append search pattern \* to the directory name */
+    p = dirp->patt + n;
+    switch (p[-1]) {
+    case '\\':
+    case '/':
+    case ':':
+        /* Directory ends in path separator, e.g. c:\temp\ */
+        /*NOP*/;
+        break;
+
+    default:
+        /* Directory name doesn't end in path separator */
+        *p++ = '\\';
+    }
+    *p++ = '*';
+    *p = '\0';
+
+    /* Open directory stream and retrieve the first entry */
+    if (!dirent_first (dirp)) {
+        goto exit_closedir;
+    }
+
+    /* Success */
+    return dirp;
+
+    /* Failure */
+exit_closedir:
+    _wclosedir (dirp);
+    return NULL;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * Returns pointer to static directory entry which may be overwritten by
+ * subsequent calls to _wreaddir().
+ */
+static struct _wdirent*
+_wreaddir(
+    _WDIR *dirp)
+{
+    struct _wdirent *entry;
+
+    /*
+     * Read directory entry to buffer.  We can safely ignore the return value
+     * as entry will be set to NULL in case of error.
+     */
+    (void) _wreaddir_r (dirp, &dirp->ent, &entry);
+
+    /* Return pointer to statically allocated directory entry */
+    return entry;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * Returns zero on success.  If end of directory stream is reached, then sets
+ * result to NULL and returns zero.
+ */
+static int
+_wreaddir_r(
+    _WDIR *dirp,
+    struct _wdirent *entry,
+    struct _wdirent **result)
+{
+    WIN32_FIND_DATAW *datap;
+
+    /* Read next directory entry */
+    datap = dirent_next (dirp);
+    if (datap) {
+        size_t n;
+        DWORD attr;
+
+        /*
+         * Copy file name as wide-character string.  If the file name is too
+         * long to fit in to the destination buffer, then truncate file name
+         * to PATH_MAX characters and zero-terminate the buffer.
+         */
+        n = 0;
+        while (n < PATH_MAX  &&  datap->cFileName[n] != 0) {
+            entry->d_name[n] = datap->cFileName[n];
+            n++;
+        }
+        entry->d_name[n] = 0;
+
+        /* Length of file name excluding zero terminator */
+        entry->d_namlen = n;
+
+        /* File type */
+        attr = datap->dwFileAttributes;
+        if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+            entry->d_type = DT_CHR;
+        } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            entry->d_type = DT_DIR;
+        } else {
+            entry->d_type = DT_REG;
+        }
+
+        /* Reset dummy fields */
+        entry->d_ino = 0;
+        entry->d_off = 0;
+        entry->d_reclen = sizeof (struct _wdirent);
+
+        /* Set result address */
+        *result = entry;
+
+    } else {
+
+        /* Return NULL to indicate end of directory */
+        *result = NULL;
+
+    }
+
+    return /*OK*/0;
+}
+
+/*
+ * Close directory stream opened by opendir() function.  This invalidates the
+ * DIR structure as well as any directory entry read previously by
+ * _wreaddir().
+ */
+static int
+_wclosedir(
+    _WDIR *dirp)
+{
+    int ok;
+    if (dirp) {
+
+        /* Release search handle */
+        if (dirp->handle != INVALID_HANDLE_VALUE) {
+            FindClose (dirp->handle);
+        }
+
+        /* Release search pattern */
+        free (dirp->patt);
+
+        /* Release directory structure */
+        free (dirp);
+        ok = /*success*/0;
+
+    } else {
+
+        /* Invalid directory stream */
+        dirent_set_errno (EBADF);
+        ok = /*failure*/-1;
+
+    }
+    return ok;
+}
+
+/*
+ * Rewind directory stream such that _wreaddir() returns the very first
+ * file name again.
+ */
+static void
+_wrewinddir(
+    _WDIR* dirp)
+{
+    if (dirp) {
+        /* Release existing search handle */
+        if (dirp->handle != INVALID_HANDLE_VALUE) {
+            FindClose (dirp->handle);
+        }
+
+        /* Open new search handle */
+        dirent_first (dirp);
+    }
+}
+
+/* Get first directory entry (internal) */
+static WIN32_FIND_DATAW*
+dirent_first(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *datap;
+    DWORD error;
+
+    /* Open directory and retrieve the first entry */
+    dirp->handle = FindFirstFileExW(
+        dirp->patt, FindExInfoStandard, &dirp->data,
+        FindExSearchNameMatch, NULL, 0);
+    if (dirp->handle != INVALID_HANDLE_VALUE) {
+
+        /* a directory entry is now waiting in memory */
+        datap = &dirp->data;
+        dirp->cached = 1;
+
+    } else {
+
+        /* Failed to open directory: no directory entry in memory */
+        dirp->cached = 0;
+        datap = NULL;
+
+        /* Set error code */
+        error = GetLastError ();
+        switch (error) {
+        case ERROR_ACCESS_DENIED:
+            /* No read access to directory */
+            dirent_set_errno (EACCES);
+            break;
+
+        case ERROR_DIRECTORY:
+            /* Directory name is invalid */
+            dirent_set_errno (ENOTDIR);
+            break;
+
+        case ERROR_PATH_NOT_FOUND:
+        default:
+            /* Cannot find the file */
+            dirent_set_errno (ENOENT);
+        }
+
+    }
+    return datap;
+}
+
+/*
+ * Get next directory entry (internal).
+ *
+ * Returns
+ */
+static WIN32_FIND_DATAW*
+dirent_next(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *p;
+
+    /* Get next directory entry */
+    if (dirp->cached != 0) {
+
+        /* A valid directory entry already in memory */
+        p = &dirp->data;
+        dirp->cached = 0;
+
+    } else if (dirp->handle != INVALID_HANDLE_VALUE) {
+
+        /* Get the next directory entry from stream */
+        if (FindNextFileW (dirp->handle, &dirp->data) != FALSE) {
+            /* Got a file */
+            p = &dirp->data;
+        } else {
+            /* The very last entry has been processed or an error occurred */
+            FindClose (dirp->handle);
+            dirp->handle = INVALID_HANDLE_VALUE;
+            p = NULL;
+        }
+
+    } else {
+
+        /* End of directory stream reached */
+        p = NULL;
+
+    }
+
+    return p;
+}
+
+/*
+ * Open directory stream using plain old C-string.
+ */
+static DIR*
+opendir(
+    const char *dirname)
+{
+    struct DIR *dirp;
+
+    /* Must have directory name */
+    if (dirname == NULL  ||  dirname[0] == '\0') {
+        dirent_set_errno (ENOENT);
+        return NULL;
+    }
+
+    /* Allocate memory for DIR structure */
+    dirp = (DIR*) malloc (sizeof (struct DIR));
+    if (!dirp) {
+        return NULL;
+    }
+    {
+        int error;
+        wchar_t wname[PATH_MAX + 1];
+        size_t n;
+
+        /* Convert directory name to wide-character string */
+        error = dirent_mbstowcs_s(
+            &n, wname, PATH_MAX + 1, dirname, PATH_MAX + 1);
+        if (error) {
+            /*
+             * Cannot convert file name to wide-character string.  This
+             * occurs if the string contains invalid multi-byte sequences or
+             * the output buffer is too small to contain the resulting
+             * string.
+             */
+            goto exit_free;
+        }
+
+
+        /* Open directory stream using wide-character name */
+        dirp->wdirp = _wopendir (wname);
+        if (!dirp->wdirp) {
+            goto exit_free;
+        }
+
+    }
+
+    /* Success */
+    return dirp;
+
+    /* Failure */
+exit_free:
+    free (dirp);
+    return NULL;
+}
+
+/*
+ * Read next directory entry.
+ */
+static struct dirent*
+readdir(
+    DIR *dirp)
+{
+    struct dirent *entry;
+
+    /*
+     * Read directory entry to buffer.  We can safely ignore the return value
+     * as entry will be set to NULL in case of error.
+     */
+    (void) readdir_r (dirp, &dirp->ent, &entry);
+
+    /* Return pointer to statically allocated directory entry */
+    return entry;
+}
+
+/*
+ * Read next directory entry into called-allocated buffer.
+ *
+ * Returns zero on success.  If the end of directory stream is reached, then
+ * sets result to NULL and returns zero.
+ */
+static int
+readdir_r(
+    DIR *dirp,
+    struct dirent *entry,
+    struct dirent **result)
+{
+    WIN32_FIND_DATAW *datap;
+
+    /* Read next directory entry */
+    datap = dirent_next (dirp->wdirp);
+    if (datap) {
+        size_t n;
+        int error;
+
+        /* Attempt to convert file name to multi-byte string */
+        error = dirent_wcstombs_s(
+            &n, entry->d_name, PATH_MAX + 1, datap->cFileName, PATH_MAX + 1);
+
+        /*
+         * If the file name cannot be represented by a multi-byte string,
+         * then attempt to use old 8+3 file name.  This allows traditional
+         * Unix-code to access some file names despite of unicode
+         * characters, although file names may seem unfamiliar to the user.
+         *
+         * Be ware that the code below cannot come up with a short file
+         * name unless the file system provides one.  At least
+         * VirtualBox shared folders fail to do this.
+         */
+        if (error  &&  datap->cAlternateFileName[0] != '\0') {
+            error = dirent_wcstombs_s(
+                &n, entry->d_name, PATH_MAX + 1,
+                datap->cAlternateFileName, PATH_MAX + 1);
+        }
+
+        if (!error) {
+            DWORD attr;
+
+            /* Length of file name excluding zero terminator */
+            entry->d_namlen = n - 1;
+
+            /* File attributes */
+            attr = datap->dwFileAttributes;
+            if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+                entry->d_type = DT_CHR;
+            } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                entry->d_type = DT_DIR;
+            } else {
+                entry->d_type = DT_REG;
+            }
+
+            /* Reset dummy fields */
+            entry->d_ino = 0;
+            entry->d_off = 0;
+            entry->d_reclen = sizeof (struct dirent);
+
+        } else {
+
+            /*
+             * Cannot convert file name to multi-byte string so construct
+             * an erroneous directory entry and return that.  Note that
+             * we cannot return NULL as that would stop the processing
+             * of directory entries completely.
+             */
+            entry->d_name[0] = '?';
+            entry->d_name[1] = '\0';
+            entry->d_namlen = 1;
+            entry->d_type = DT_UNKNOWN;
+            entry->d_ino = 0;
+            entry->d_off = -1;
+            entry->d_reclen = 0;
+
+        }
+
+        /* Return pointer to directory entry */
+        *result = entry;
+
+    } else {
+
+        /* No more directory entries */
+        *result = NULL;
+
+    }
+
+    return /*OK*/0;
+}
+
+/*
+ * Close directory stream.
+ */
+static int
+closedir(
+    DIR *dirp)
+{
+    int ok;
+    if (dirp) {
+
+        /* Close wide-character directory stream */
+        ok = _wclosedir (dirp->wdirp);
+        dirp->wdirp = NULL;
+
+        /* Release multi-byte character version */
+        free (dirp);
+
+    } else {
+
+        /* Invalid directory stream */
+        dirent_set_errno (EBADF);
+        ok = /*failure*/-1;
+
+    }
+    return ok;
+}
+
+/*
+ * Rewind directory stream to beginning.
+ */
+static void
+rewinddir(
+    DIR* dirp)
+{
+    /* Rewind wide-character string directory stream */
+    _wrewinddir (dirp->wdirp);
+}
+
+/*
+ * Scan directory for entries.
+ */
+static int
+scandir(
+    const char *dirname,
+    struct dirent ***namelist,
+    int (*filter)(const struct dirent*),
+    int (*compare)(const struct dirent**, const struct dirent**))
+{
+    struct dirent **files = NULL;
+    size_t size = 0;
+    size_t allocated = 0;
+    const size_t init_size = 1;
+    DIR *dir = NULL;
+    struct dirent *entry;
+    struct dirent *tmp = NULL;
+    size_t i;
+    int result = 0;
+
+    /* Open directory stream */
+    dir = opendir (dirname);
+    if (dir) {
+
+        /* Read directory entries to memory */
+        while (1) {
+
+            /* Enlarge pointer table to make room for another pointer */
+            if (size >= allocated) {
+                void *p;
+                size_t num_entries;
+
+                /* Compute number of entries in the enlarged pointer table */
+                if (size < init_size) {
+                    /* Allocate initial pointer table */
+                    num_entries = init_size;
+                } else {
+                    /* Double the size */
+                    num_entries = size * 2;
+                }
+
+                /* Allocate first pointer table or enlarge existing table */
+                p = realloc (files, sizeof (void*) * num_entries);
+                if (p != NULL) {
+                    /* Got the memory */
+                    files = (dirent**) p;
+                    allocated = num_entries;
+                } else {
+                    /* Out of memory */
+                    result = -1;
+                    break;
+                }
+
+            }
+
+            /* Allocate room for temporary directory entry */
+            if (tmp == NULL) {
+                tmp = (struct dirent*) malloc (sizeof (struct dirent));
+                if (tmp == NULL) {
+                    /* Cannot allocate temporary directory entry */
+                    result = -1;
+                    break;
+                }
+            }
+
+            /* Read directory entry to temporary area */
+            if (readdir_r (dir, tmp, &entry) == /*OK*/0) {
+
+                /* Did we get an entry? */
+                if (entry != NULL) {
+                    int pass;
+
+                    /* Determine whether to include the entry in result */
+                    if (filter) {
+                        /* Let the filter function decide */
+                        pass = filter (tmp);
+                    } else {
+                        /* No filter function, include everything */
+                        pass = 1;
+                    }
+
+                    if (pass) {
+                        /* Store the temporary entry to pointer table */
+                        files[size++] = tmp;
+                        tmp = NULL;
+
+                        /* Keep up with the number of files */
+                        result++;
+                    }
+
+                } else {
+
+                    /*
+                     * End of directory stream reached => sort entries and
+                     * exit.
+                     */
+                    qsort (files, size, sizeof (void*),
+                        (int (*) (const void*, const void*)) compare);
+                    break;
+
+                }
+
+            } else {
+                /* Error reading directory entry */
+                result = /*Error*/ -1;
+                break;
+            }
+
+        }
+
+    } else {
+        /* Cannot open directory */
+        result = /*Error*/ -1;
+    }
+
+    /* Release temporary directory entry */
+    free (tmp);
+
+    /* Release allocated memory on error */
+    if (result < 0) {
+        for (i = 0; i < size; i++) {
+            free (files[i]);
+        }
+        free (files);
+        files = NULL;
+    }
+
+    /* Close directory stream */
+    if (dir) {
+        closedir (dir);
+    }
+
+    /* Pass pointer table to caller */
+    if (namelist) {
+        *namelist = files;
+    }
+    return result;
+}
+
+/* Alphabetical sorting */
+static int
+alphasort(
+    const struct dirent **a, const struct dirent **b)
+{
+    return strcoll ((*a)->d_name, (*b)->d_name);
+}
+
+/* Sort versions */
+static int
+versionsort(
+    const struct dirent **a, const struct dirent **b)
+{
+    /* FIXME: implement strverscmp and use that */
+    return alphasort (a, b);
+}
+
+/* Convert multi-byte string to wide character string */
+static int
+dirent_mbstowcs_s(
+    size_t *pReturnValue,
+    wchar_t *wcstr,
+    size_t sizeInWords,
+    const char *mbstr,
+    size_t count)
+{
+    int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 or later */
+    error = mbstowcs_s (pReturnValue, wcstr, sizeInWords, mbstr, count);
+
+#else
+
+    /* Older Visual Studio or non-Microsoft compiler */
+    size_t n;
+
+    /* Convert to wide-character string (or count characters) */
+    n = mbstowcs (wcstr, mbstr, sizeInWords);
+    if (!wcstr  ||  n < count) {
+
+        /* Zero-terminate output buffer */
+        if (wcstr  &&  sizeInWords) {
+            if (n >= sizeInWords) {
+                n = sizeInWords - 1;
+            }
+            wcstr[n] = 0;
+        }
+
+        /* Length of resulting multi-byte string WITH zero terminator */
+        if (pReturnValue) {
+            *pReturnValue = n + 1;
+        }
+
+        /* Success */
+        error = 0;
+
+    } else {
+
+        /* Could not convert string */
+        error = 1;
+
+    }
+
+#endif
+    return error;
+}
+
+/* Convert wide-character string to multi-byte string */
+static int
+dirent_wcstombs_s(
+    size_t *pReturnValue,
+    char *mbstr,
+    size_t sizeInBytes, /* max size of mbstr */
+    const wchar_t *wcstr,
+    size_t count)
+{
+    int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 or later */
+    error = wcstombs_s (pReturnValue, mbstr, sizeInBytes, wcstr, count);
+
+#else
+
+    /* Older Visual Studio or non-Microsoft compiler */
+    size_t n;
+
+    /* Convert to multi-byte string (or count the number of bytes needed) */
+    n = wcstombs (mbstr, wcstr, sizeInBytes);
+    if (!mbstr  ||  n < count) {
+
+        /* Zero-terminate output buffer */
+        if (mbstr  &&  sizeInBytes) {
+            if (n >= sizeInBytes) {
+                n = sizeInBytes - 1;
+            }
+            mbstr[n] = '\0';
+        }
+
+        /* Length of resulting multi-bytes string WITH zero-terminator */
+        if (pReturnValue) {
+            *pReturnValue = n + 1;
+        }
+
+        /* Success */
+        error = 0;
+
+    } else {
+
+        /* Cannot convert string */
+        error = 1;
+
+    }
+
+#endif
+    return error;
+}
+
+/* Set errno variable */
+static void
+dirent_set_errno(
+    int error)
+{
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 and later */
+    _set_errno (error);
+
+#else
+
+    /* Non-Microsoft compiler or older Microsoft compiler */
+    errno = error;
+
+#endif
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*DIRENT_H*/

--- a/external/getopt/CMakeLists.txt
+++ b/external/getopt/CMakeLists.txt
@@ -1,0 +1,13 @@
+# CMake buildfile generator file.
+# Process with cmake to create your desired buildfiles.
+
+# (c) 2019, Dominik Schnitzer <dominik@schnitzer.at>
+
+add_library(getopt_windows STATIC
+    getopt.c)
+
+target_include_directories(getopt_windows INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR})
+
+target_compile_options(getopt_windows PRIVATE
+    /W4)

--- a/external/getopt/getopt.c
+++ b/external/getopt/getopt.c
@@ -1,0 +1,52 @@
+/* *****************************************************************
+*
+* Copyright 2016 Microsoft
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************/
+
+#include "getopt.h"
+#include <windows.h>
+
+char* optarg = NULL;
+int optind = 1;
+
+int getopt(int argc, char *const argv[], const char *optstring)
+{
+    if ((optind >= argc) || (argv[optind][0] != '-') || (argv[optind][0] == 0))
+    {
+        return -1;
+    }
+
+    int opt = argv[optind][1];
+    const char *p = strchr(optstring, opt);
+
+    if (p == NULL)
+    {
+        return '?';
+    }
+    optind++;
+    if (p[1] == ':')
+    {
+        if (optind >= argc)
+        {
+            return '?';
+        }
+        optarg = argv[optind];
+        optind++;
+    }
+    return opt;
+}
+

--- a/external/getopt/getopt.h
+++ b/external/getopt/getopt.h
@@ -1,0 +1,37 @@
+/* *****************************************************************
+*
+* Copyright 2016 Microsoft
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************/
+
+#ifndef GETOPT_H__
+#define GETOPT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern char *optarg;
+extern int optind;
+
+int getopt(int argc, char *const argv[], const char *optstring);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/include/minilog.h
+++ b/include/minilog.h
@@ -75,8 +75,8 @@ minilog_get_timestr()
     }
 
     char result[MAX_LEN*2] = {0};
-    static DWORD first = GetTickCount();
-    sprintf(result, "%s.%03ld", buffer, (long)(GetTickCount() - first) % 1000);
+    static ULONGLONG first = GetTickCount64();
+    sprintf(result, "%s.%03lld", buffer, (LONGLONG)(GetTickCount64() - first) % 1000);
 
     return result;
 }

--- a/include/minilog.h
+++ b/include/minilog.h
@@ -94,7 +94,7 @@ minilog_get_timestr()
 
     time_t t;
     time(&t);
-    tm r = {0};
+    tm r = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     strftime(buffer, sizeof(buffer), "%X", localtime_r(&t, &r));
 
     char result[MAX_LEN*2] = {0};

--- a/include/musly/musly.h
+++ b/include/musly/musly.h
@@ -38,7 +38,9 @@ similarity measures. It is our reference implementation.
 
 /** \hideinitializer Macro marking the exported symbols of the library */
 #if defined(_WIN32) || defined(__CYGWIN__)
-  #ifdef MUSLY_BUILDING_LIBRARY
+  #ifdef MUSLY_BUILDING_STATIC
+    #define MUSLY_EXPORT
+  #elif MUSLY_BUILDING_LIBRARY
     #define MUSLY_EXPORT __declspec(dllexport)
   #else
     #define MUSLY_EXPORT __declspec(dllimport)

--- a/libmusly/CMakeLists.txt
+++ b/libmusly/CMakeLists.txt
@@ -51,6 +51,9 @@ if (MSVC)
     # kissfft does not compile with warning level>2
     target_compile_options(kissfft PRIVATE
         /W2)
+else()
+    target_compile_options(kissfft PRIVATE
+        -pedantic -Wextra)
 endif()
 
 
@@ -74,6 +77,9 @@ if (MSVC)
     # libresample does not compile with warning level>1
     target_compile_options(libresample PRIVATE
         /W1)
+else()
+    target_compile_options(kissfft PRIVATE
+        -pedantic)
 endif()
 
 

--- a/libmusly/CMakeLists.txt
+++ b/libmusly/CMakeLists.txt
@@ -143,6 +143,11 @@ target_include_directories(libmusly
     ${EIGEN3_INCLUDE_DIR}
     ${LIBAV_INCLUDE_DIRS}
 )
+if (MSVC)
+    # Disable warnings for MSBuild from external libraries
+    target_compile_options(libmusly PRIVATE
+	    /wd4244)
+endif()
 
 source_group("libmusly" FILES
     ${LIBMUSLY_CPP}

--- a/libmusly/CMakeLists.txt
+++ b/libmusly/CMakeLists.txt
@@ -73,6 +73,8 @@ add_library(libresample STATIC
     ${LIBRESAMPLE_C}
     ${LIBRESAMPLE_H}
 )
+target_include_directories(libresample PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}/libresample)
 if (MSVC)
     # libresample does not compile with warning level>1
     target_compile_options(libresample PRIVATE

--- a/libmusly/CMakeLists.txt
+++ b/libmusly/CMakeLists.txt
@@ -4,9 +4,6 @@
 # (c) 2013-2014, Dominik Schnitzer <dominik@schnitzer.at>
 #     2014-2016, Jan Schlueter <jan.schlueter@ofai.at>
 
-add_subdirectory(
-    libresample)
-
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external")
     add_subdirectory(
         external)
@@ -15,6 +12,10 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external")
     set_source_files_properties(lib.cpp
         PROPERTIES COMPILE_FLAGS "-DLIBMUSLY_EXTERNAL ${LIBMUSLY_EXTERNAL_FLAGS}")
 endif()
+
+# configure libresample
+find_file(HAVE_INTTYPES inttypes.h)
+configure_file(libresample/config.h.in libresample/config.h)
 
 if(EXISTS "${LIBAV_INCLUDE_DIRS}/libavutil/channel_layout.h")
     set_source_files_properties(decoders/libav.cpp
@@ -29,16 +30,55 @@ endif()
 
 include_directories(
     ${LIBMUSLY_INCLUDE}
-    ${EIGEN3_INCLUDE_DIR}
-    ${LIBAV_INCLUDE_DIRS}
-    ${CMAKE_CURRENT_SOURCE_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
-add_library(libmusly
+
+# KissFFT
+set(KISSFFT_C
     kissfft/kiss_fft.c
     kissfft/kiss_fftr.c
-    methods/mandelellis.cpp
-    methods/timbre.cpp
-    decoders/libav.cpp
+)
+set(KISSFFT_H
+    kissfft/kiss_fft.h
+    kissfft/kiss_fftr.h
+)
+add_library(kissfft STATIC
+    ${KISSFFT_C}
+    ${KISSFFT_H}
+)
+if (MSVC)
+    # kissfft does not compile with warning level>2
+    target_compile_options(kissfft PRIVATE
+        /W2)
+endif()
+
+
+# libresample
+set(LIBRESAMPLE_C
+    libresample/filterkit.c
+    libresample/resamplesubs.c
+    libresample/resample.c
+)
+set(LIBRESAMPLE_H
+    libresample/filterkit.h
+    libresample/libresample.h
+    libresample/resample_defs.h
+    libresample/config.h.in
+)
+add_library(libresample STATIC
+    ${LIBRESAMPLE_C}
+    ${LIBRESAMPLE_H}
+)
+if (MSVC)
+    # libresample does not compile with warning level>1
+    target_compile_options(libresample PRIVATE
+        /W1)
+endif()
+
+
+# libmusly
+set(LIBMUSLY_CPP
     resampler.cpp
     plugins.cpp
     method.cpp
@@ -51,24 +91,91 @@ add_library(libmusly
     gaussianstatistics.cpp
     mutualproximity.cpp
     lib.cpp
-    ${LIBMUSLY_EXTERNAL})
+)
+set(LIBMUSLY_METHODS_CPP
+    methods/mandelellis.cpp
+    methods/timbre.cpp
+)
+set(LIBMUSLY_METHODS_H
+    methods/mandelellis.h
+    methods/timbre.h
+)
+set(LIBMUSLY_DECODERS_CPP
+    decoders/libav.cpp
+)
+set(LIBMUSLY_DECODERS_H
+    decoders/libav.h
+)
+set(LIBMUSLY_H
+    resampler.h
+    plugins.h
+    method.h
+    decoder.h
+    windowfunction.h
+    powerspectrum.h
+    melspectrum.h
+    discretecosinetransform.h
+    mfcc.h
+    gaussianstatistics.h
+    mutualproximity.h
+)
+
+add_library(libmusly
+    ${LIBMUSLY_CPP}
+    ${LIBMUSLY_H}
+    ${LIBMUSLY_METHODS_CPP}
+    ${LIBMUSLY_METHODS_H}
+    ${LIBMUSLY_DECODERS_CPP}
+    ${LIBMUSLY_DECODERS_H}
+)
+
+target_include_directories(libmusly
+    SYSTEM
+    PRIVATE
+    ${EIGEN3_INCLUDE_DIR}
+    ${LIBAV_INCLUDE_DIRS}
+)
+
+source_group("libmusly" FILES
+    ${LIBMUSLY_CPP}
+    ${LIBMUSLY_H}
+)
+source_group("libmusly\\methods" FILES
+    ${LIBMUSLY_METHODS_CPP}
+    ${LIBMUSLY_METHODS_H}
+)
+source_group("libmusly\\decoders" FILES
+    ${LIBMUSLY_DECODERS_CPP}
+    ${LIBMUSLY_DECODERS_H}
+)
+source_group("kissfft" FILES
+    ${KISSFFT_C}
+    ${KISSFFT_H}
+)
+source_group("libresample" FILES
+    ${LIBRESAMPLE_C}
+    ${LIBRESAMPLE_H}
+)
 
 if(BUILD_STATIC)
-    set_target_properties(libmusly
-        PROPERTIES COMPILE_FLAGS "-DBUILD_STATIC")
+    target_compile_definitions(libmusly PRIVATE
+        BUILD_STATIC MUSLY_BUILDING_STATIC)
+else()
+    # This defines MUSLY_BUILDING_LIBRARY *only when building as shared library*,
+    # allowing us to use __declspec(dllexport) instead of dllimport on Windows.
+    target_compile_definitions(libmusly PRIVATE
+        MUSLY_BUILDING_LIBRARY)
 endif()
 
-# This defines MUSLY_BUILDING_LIBRARY *only when building as shared library*,
-# allowing us to use __declspec(dllexport) instead of dllimport on Windows.
-set_target_properties(libmusly
-    PROPERTIES DEFINE_SYMBOL MUSLY_BUILDING_LIBRARY)
-
 target_link_libraries(libmusly
+    kissfft
+    libresample
     ${LIBMUSLY_LIBS}
     ${LIBAV_LIBRARIES})
 if(WIN32 OR MINGW)
     # link against winsock2 for ntohl() and htonl()
-    target_link_libraries(libmusly ws2_32)
+    target_link_libraries(libmusly
+        ws2_32)
 endif()
 
 set_target_properties(libmusly

--- a/libmusly/decoder.h
+++ b/libmusly/decoder.h
@@ -41,7 +41,7 @@ public:
 #ifndef BUILD_STATIC
 #define MUSLY_DECODER_REGCLASS(classname) \
 private: \
-    static const plugin_creator_impl<classname> creator;
+    static const plugin_creator_impl<classname> creator
 #else
 #define MUSLY_DECODER_REGCLASS(classname)
 #endif
@@ -55,7 +55,7 @@ private: \
 #ifndef BUILD_STATIC
 #define MUSLY_DECODER_REGIMPL(classname, priority) \
     const plugin_creator_impl<classname> classname::creator(#classname, \
-            plugins::DECODER_TYPE, priority);
+            plugins::DECODER_TYPE, priority)
 #else
 #define MUSLY_DECODER_REGIMPL(classname, priority)
 #endif
@@ -68,7 +68,7 @@ private: \
 #define MUSLY_DECODER_REGSTATIC(classname, priority) \
     static const musly::plugin_creator_impl<musly::decoders::classname> \
             create ## _ ## classname (#classname, \
-            musly::plugins::DECODER_TYPE, priority);
+            musly::plugins::DECODER_TYPE, priority)
 #endif
 
 } /* namespace musly */

--- a/libmusly/decoders/libav.cpp
+++ b/libmusly/decoders/libav.cpp
@@ -296,7 +296,7 @@ libav::decodeto_22050hz_mono_float(
         // fault when trying to access frame->data[i] for i > 0 further below)
         if ((excerpt_start > 0) && (av_seek_frame(fmtx, audio_stream_idx,
                     static_cast<int64_t>(static_cast<double>(excerpt_start) * st->time_base.den) / st->time_base.num,
-                    AVSEEK_FLAG_BACKWARD || AVSEEK_FLAG_ANY) >= 0)) {
+                    AVSEEK_FLAG_BACKWARD | AVSEEK_FLAG_ANY) >= 0)) {
             // skipping went fine: decode only what's needed
             decode_samples = static_cast<int>(excerpt_length * decx->sample_rate);
             excerpt_start = 0;

--- a/libmusly/decoders/libav.cpp
+++ b/libmusly/decoders/libav.cpp
@@ -54,7 +54,7 @@ extern "C" {
 namespace musly {
 namespace decoders {
 
-MUSLY_DECODER_REGIMPL(libav, 0);
+MUSLY_DECODER_REGIMPL(libav, 0)
 
 libav::libav()
 {

--- a/libmusly/decoders/libav.h
+++ b/libmusly/decoders/libav.h
@@ -25,7 +25,7 @@ namespace decoders {
 class libav :
     public musly::decoder
 {
-    MUSLY_DECODER_REGCLASS(libav);
+    MUSLY_DECODER_REGCLASS(libav)
 
 private:
     int

--- a/libmusly/gaussianstatistics.cpp
+++ b/libmusly/gaussianstatistics.cpp
@@ -131,7 +131,7 @@ gaussian_statistics::jensenshannon(
 
     // merge the mean and covariance matrices to get the merged Gaussian
     for (int i = 0; i < d; i++) {
-        tmp.mu[i] = 0.5*(g0.mu[i] - g1.mu[i]);
+        tmp.mu[i] = static_cast<float>(0.5*(g0.mu[i] - g1.mu[i]));
     }
     int idx_covar = 0;
     for (int i = 0; i < d; i++) {

--- a/libmusly/gaussianstatistics.cpp
+++ b/libmusly/gaussianstatistics.cpp
@@ -75,7 +75,7 @@ gaussian_statistics::estimate_gaussian(
 
     // Add Gaussian noise to the data to avoid singular covariance matrices
     // in case the input data was silence.
-    covar.diagonal().array() += 1e-4;
+    covar.diagonal().array() += 1e-4f;
     if (g.covar) {
         int idx_ij = 0;
         for (int i = 0; i < d; i++) {

--- a/libmusly/gaussianstatistics.cpp
+++ b/libmusly/gaussianstatistics.cpp
@@ -164,7 +164,7 @@ gaussian_statistics::jensenshannon(
         for (int j = i+1; j < d; j++) {
             idx_ij++;
 
-            int idx_k = 0;
+            idx_k = 0;
             for (int k = 0; k < i; k++) {
                 tmp.covar[idx_ij] -=
                         tmp.covar[idx_k+i] * tmp.covar[idx_k+j];

--- a/libmusly/idpool.h
+++ b/libmusly/idpool.h
@@ -95,7 +95,7 @@ public:
 
     int
     get_size() {
-        return registered_ids.size();
+        return static_cast<int>(registered_ids.size());
     }
 
     int
@@ -182,8 +182,8 @@ public:
     ordered_idpool() : observer(NULL) {};
 
     void
-    set_observer(ordered_idpool_observer* observer) {
-        this->observer = observer;
+    set_observer(ordered_idpool_observer* obs) {
+        this->observer = obs;
     }
 
     inline const std::vector<T>& idlist() const {
@@ -209,7 +209,7 @@ public:
 
     inline int
     get_size() {
-        return registered_ids.size();
+        return static_cast<int>(registered_ids.size());
     }
 
     /** Move a bunch of ids to the end of idlist(), in their given order.
@@ -217,7 +217,7 @@ public:
      */
     int
     move_to_end(T* ids, int length) {
-        int start = registered_ids.size();
+        int start = static_cast<int>(registered_ids.size());
         for (int i = length - 1; i >= 0; i--) {
             typename std::map<T,int>::iterator it = positions.find(ids[i]);
             if (it != positions.end()) {
@@ -225,7 +225,7 @@ public:
                 swap_positions(it->second, start, it);
             }
         }
-        return registered_ids.size() - start;
+        return static_cast<int>(registered_ids.size()) - start;
     }
 
     /** Register a bunch of ids and return how many of them were new
@@ -236,8 +236,8 @@ public:
         // move all known ids to the end
         int num_known = move_to_end(ids, length);
         // make enough room to add unknown ids
-        int start = registered_ids.size() - num_known;
-        registered_ids.resize(start + length);
+        int start = static_cast<int>(registered_ids.size()) - num_known;
+        registered_ids.resize(static_cast<size_t>(start + length));
         // overwrite the last `length` elements with the given `ids`
         for (int i = 0; i < length; i++) {
             registered_ids[start + i] = ids[i];
@@ -259,12 +259,12 @@ public:
             ids[i] = ++idpool<T>::max_seen;
         }
         // make enough room to add all ids
-        int size = registered_ids.size();
+        size_t size = registered_ids.size();
         registered_ids.reserve(size + length);
         // append ids to the end
         for (int i = 0; i < length; i++) {
             registered_ids.push_back(ids[i]);
-            positions[ids[i]] = size++;
+            positions[ids[i]] = static_cast<int>(size++);
         }
     }
 
@@ -282,7 +282,7 @@ public:
      */
     void
     remove_last(int length) {
-        int start = registered_ids.size() - length;
+        int start = static_cast<int>(registered_ids.size()) - length;
         for (int i = start; i < start + length; i++) {
             positions.erase(registered_ids[i]);
         }

--- a/libmusly/lib.cpp
+++ b/libmusly/lib.cpp
@@ -408,7 +408,7 @@ musly_jukebox_tostream(
     if (fputs(musly_version(), stream) == EOF || fputc('\0', stream) == EOF) {
         return -1;
     }
-    written += strlen(musly_version()) + 1;
+    written += static_cast<int>(strlen(musly_version())) + 1;
 
     // write platform information
     const uint8_t intsize = sizeof(int);
@@ -419,7 +419,7 @@ musly_jukebox_tostream(
     if (fwrite(&byteorder, sizeof(byteorder), 1, stream) != 1) {
         return -1;
     }
-    written += sizeof(intsize) + sizeof(byteorder);
+    written += static_cast<int>(sizeof(intsize) + sizeof(byteorder));
 
     // write general jukebox information
     if (fputs(jukebox->method_name, stream) == EOF ||
@@ -428,8 +428,8 @@ musly_jukebox_tostream(
             fputc('\0', stream) == EOF) {
         return -1;
     }
-    written += strlen(jukebox->method_name) + 1;
-    written += strlen(jukebox->decoder_name) + 1;
+    written += static_cast<int>(strlen(jukebox->method_name)) + 1;
+    written += static_cast<int>(strlen(jukebox->decoder_name)) + 1;
 
     unsigned char* buffer;
     int bcount;
@@ -732,7 +732,7 @@ musly_track_analyze_audiofile(
         }
 
         // pass it on to build the similarity model
-        return musly_track_analyze_pcm(jukebox, pcm.data(), pcm.size(), track);
+        return musly_track_analyze_pcm(jukebox, pcm.data(), static_cast<int>(pcm.size()), track);
 
     } else {
         return -1;

--- a/libmusly/lib.cpp
+++ b/libmusly/lib.cpp
@@ -12,8 +12,6 @@
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
 #include <winsock2.h>
-typedef u_long uint32_t;
-typedef unsigned char uint8_t;
 #else
 #include <arpa/inet.h>
 #endif
@@ -737,7 +735,6 @@ musly_track_analyze_audiofile(
     } else {
         return -1;
     }
-    return 0;
 }
 
 typedef std::pair<float, musly_trackid> knn;

--- a/libmusly/melspectrum.cpp
+++ b/libmusly/melspectrum.cpp
@@ -29,8 +29,8 @@ melspectrum::melspectrum(
             0.0f, sample_rate/2.0f);
 
     // determine the best mel bin for each frequency
-    Eigen::VectorXf freq = Eigen::VectorXf::LinSpaced(sample_rate/2-min_freq,
-            min_freq, sample_rate/2);
+    Eigen::VectorXf freq = Eigen::VectorXf::LinSpaced(sample_rate/2-static_cast<int>(min_freq),
+            min_freq, sample_rate/2.f);
     Eigen::VectorXf mel = ((freq/700.0f).array() + 1.0f).log() * 1127.01048f;
     Eigen::VectorXf mel_idx = Eigen::VectorXf::LinSpaced(mel_bins+2,
             1.0f, mel.maxCoeff());

--- a/libmusly/method.cpp
+++ b/libmusly/method.cpp
@@ -62,7 +62,7 @@ method::track_tostr(
     // TODO: Use and reuse a string buffer
     trackstr = "";
     int offs = 0;
-    int buffer_size = 256;
+    const int buffer_size = 256;
     char buffer[buffer_size];
     for (int i = 0; i < (int)track_field_name.size(); i++) {
         trackstr += track_field_name[i] + ":";

--- a/libmusly/method.cpp
+++ b/libmusly/method.cpp
@@ -79,19 +79,19 @@ method::track_tostr(
 
 int
 method::set_musicstyle(
-        musly_track** tracks,
-        int length)
+        musly_track** /*tracks*/,
+        int /*length*/)
 {
     return 0;
 }
 
 int
 method::guess_neighbors(
-        musly_trackid seed,
-        musly_trackid* neighbors,
-        int length,
-        musly_trackid* limit_to,
-        int num_limit_to)
+        musly_trackid /*seed*/,
+        musly_trackid* /*neighbors*/,
+        int /*length*/,
+        musly_trackid* /*limit_to*/,
+        int /*num_limit_to*/)
 {
     // all tracks
     return -1;
@@ -115,17 +115,17 @@ method::deserialize_metadata(
 
 int
 method::serialize_trackdata(
-        unsigned char* buffer,
-        int num_tracks,
-        int skip_tracks) {
+        unsigned char* /*buffer*/,
+        int /*num_tracks*/,
+        int /*skip_tracks*/) {
     // default: not implemented
     return -1;
 }
 
 int
 method::deserialize_trackdata(
-        unsigned char* buffer,
-        int num_tracks) {
+        unsigned char* /*buffer*/,
+        int /*num_tracks*/) {
     // default: not implemented
     return -1;
 }

--- a/libmusly/method.h
+++ b/libmusly/method.h
@@ -252,7 +252,7 @@ public:
 #ifndef BUILD_STATIC
 #define MUSLY_METHOD_REGCLASS(classname) \
 private: \
-    static const plugin_creator_impl<classname> creator;
+    static const plugin_creator_impl<classname> creator
 #else
 #define MUSLY_METHOD_REGCLASS(classname)
 #endif
@@ -266,7 +266,7 @@ private: \
 #ifndef BUILD_STATIC
 #define MUSLY_METHOD_REGIMPL(classname, priority) \
     const plugin_creator_impl<classname> classname::creator(#classname, \
-            plugins::METHOD_TYPE, priority);
+            plugins::METHOD_TYPE, priority)
 #else
 #define MUSLY_METHOD_REGIMPL(classname, priority)
 #endif
@@ -279,7 +279,7 @@ private: \
 #define MUSLY_METHOD_REGSTATIC(classname, priority) \
     static const musly::plugin_creator_impl<musly::methods::classname> \
             create ## _ ## classname (#classname, \
-            musly::plugins::METHOD_TYPE, priority);
+            musly::plugins::METHOD_TYPE, priority)
 #endif
 
 } /* namespace musly */

--- a/libmusly/methods/mandelellis.cpp
+++ b/libmusly/methods/mandelellis.cpp
@@ -115,9 +115,9 @@ mandelellis::analyze_track(
 int
 mandelellis::similarity(
         musly_track* track,
-        musly_trackid seed_trackid,
+        musly_trackid /*seed_trackid*/,
         musly_track** tracks,
-        musly_trackid* trackids,
+        musly_trackid* /*trackids*/,
         int length,
         float* similarities)
 {
@@ -156,7 +156,7 @@ mandelellis::similarity(
 
 int
 mandelellis::add_tracks(
-        musly_track** tracks,
+        musly_track** /*tracks*/,
         musly_trackid* trackids,
         int length,
         bool generate_ids) {

--- a/libmusly/methods/mandelellis.cpp
+++ b/libmusly/methods/mandelellis.cpp
@@ -22,7 +22,7 @@ namespace methods {
 
 /** Register mandelellis with musly with a low priority (0)
  */
-MUSLY_METHOD_REGIMPL(mandelellis, 0);
+MUSLY_METHOD_REGIMPL(mandelellis, 0)
 
 mandelellis::mandelellis() :
 

--- a/libmusly/methods/mandelellis.h
+++ b/libmusly/methods/mandelellis.h
@@ -27,7 +27,7 @@ class mandelellis :
         public musly::method
 
 {
-MUSLY_METHOD_REGCLASS(mandelellis);
+MUSLY_METHOD_REGCLASS(mandelellis)
 
 private:
 

--- a/libmusly/methods/timbre.cpp
+++ b/libmusly/methods/timbre.cpp
@@ -221,7 +221,7 @@ timbre::add_tracks(
     int pos = idpool.get_size() - length;
     for (int i = 0; i < length; i++) {
         similarity_raw(tracks[i], mp.get_normtracks()->data(),
-                mp.get_normtracks()->size(), sim.data());
+                static_cast<int>(mp.get_normtracks()->size()), sim.data());
 
         mp.set_normfacts(pos + i, sim);
     }
@@ -276,15 +276,15 @@ timbre::serialize_metadata(
 
         // mutual proximity tracks
         std::vector<musly_track*> &mptracks = *mp.get_normtracks();
-        *(int*)(buffer) = mptracks.size();
+        *(int*)(buffer) = static_cast<int>(mptracks.size());
         buffer += sizeof(int);
         for (int i = 0; i < (int)mptracks.size(); i++) {
             std::copy(mptracks[i], mptracks[i] + track_getsize(), (musly_track*)buffer);
             buffer += track_getsize() * sizeof(musly_track);
         }
     }
-    return sizeof(int) + sizeof(musly_trackid) + sizeof(int)
-            + mp.get_normtracks()->size() * track_getsize() * sizeof(musly_track);
+    return static_cast<int>(sizeof(int) + sizeof(musly_trackid) + sizeof(int)
+            + mp.get_normtracks()->size() * track_getsize() * sizeof(musly_track));
 }
 
 int

--- a/libmusly/methods/timbre.cpp
+++ b/libmusly/methods/timbre.cpp
@@ -23,7 +23,7 @@ namespace methods {
 
 /** Register timbre with musly with piority (1)
  */
-MUSLY_METHOD_REGIMPL(timbre, 1);
+MUSLY_METHOD_REGIMPL(timbre, 1)
 
 
 

--- a/libmusly/methods/timbre.h
+++ b/libmusly/methods/timbre.h
@@ -28,7 +28,7 @@ class timbre :
         public musly::method, musly::ordered_idpool_observer
 
 {
-MUSLY_METHOD_REGCLASS(timbre);
+MUSLY_METHOD_REGCLASS(timbre)
 
 private:
 

--- a/libmusly/mutualproximity.cpp
+++ b/libmusly/mutualproximity.cpp
@@ -78,7 +78,7 @@ mutualproximity::set_normfacts(
     Eigen::VectorXd sim_mu = sim.cast<double>().array() - mu;
     double std = (sim_mu.transpose() * sim_mu);
     std /= (static_cast<double>(sim.size()) - 1.0);
-    set_normfacts(position, mu, sqrt(std));
+    set_normfacts(position, static_cast<float>(mu), static_cast<float>(sqrt(std)));
 }
 
 void
@@ -171,7 +171,7 @@ mutualproximity::normalize(
 
         double p1 = 1 - normcdf((d - seed_mu)/seed_std);
         double p2 = 1 - normcdf((d - norm_facts[pos].mu)/norm_facts[pos].std);
-        sim[i] = 1 - p1*p2;
+        sim[i] = static_cast<float>(1 - p1*p2);
     }
     return 0;
 }

--- a/libmusly/powerspectrum.cpp
+++ b/libmusly/powerspectrum.cpp
@@ -21,8 +21,8 @@ powerspectrum::powerspectrum(
         float hop)
 {
     this->win_funct = win_funct;
-    this->win_size = win_funct.size();
-    this->hop_size = hop*win_size;
+    this->win_size = static_cast<int>(win_funct.size());
+    this->hop_size = static_cast<int>(hop*win_size);
 
     // initialize kiss fft
     kiss_pcm = (kiss_fft_scalar*)malloc(sizeof(kiss_fft_scalar) * win_size);

--- a/libmusly/resampler.cpp
+++ b/libmusly/resampler.cpp
@@ -32,10 +32,10 @@ std::vector<float> resampler::resample(
         float* pcm_input,
         int pcm_len)
 {
-    std::vector<float> pcm_out(pcm_len*resample_factor);
+    std::vector<float> pcm_out(static_cast<size_t>(pcm_len*resample_factor));
 
     int srclen = 4096;
-    int dstlen = (srclen*resample_factor + 1000);
+    int dstlen = static_cast<int>(srclen*resample_factor + 1000.);
     float* dst = new float[dstlen];
 
     int in_pos = 0;

--- a/libmusly/resampler.cpp
+++ b/libmusly/resampler.cpp
@@ -17,8 +17,6 @@
 namespace musly {
 
 resampler::resampler(int input_rate, int output_rate):
-        input_rate(input_rate),
-        output_rate(output_rate),
         resample_factor((double)output_rate/(double)input_rate)
 {
     libresample = resample_open(1, resample_factor, resample_factor);

--- a/libmusly/resampler.cpp
+++ b/libmusly/resampler.cpp
@@ -9,8 +9,9 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include "resampler.h"
+#include <algorithm>
 
+#include "resampler.h"
 #include "minilog.h"
 
 namespace musly {

--- a/libmusly/resampler.h
+++ b/libmusly/resampler.h
@@ -21,8 +21,6 @@ namespace musly {
 
 class resampler {
 private:
-    int input_rate;
-    int output_rate;
     double resample_factor;
 
     void* libresample;

--- a/libmusly/windowfunction.cpp
+++ b/libmusly/windowfunction.cpp
@@ -19,8 +19,8 @@ namespace musly {
 Eigen::VectorXf windowfunction::hann(
         int window_size)
 {
-    int N = window_size - 1;
-    Eigen::VectorXf n = Eigen::VectorXf::LinSpaced(window_size, 0, N);
+    float N = window_size - 1.f;
+    Eigen::VectorXf n = Eigen::VectorXf::LinSpaced(window_size, 0.f, N);
     Eigen::VectorXf w = 0.5f * (1.0f - (2.0f*M_PI*n/N).array().cos());
     return w;
 }

--- a/musly/CMakeLists.txt
+++ b/musly/CMakeLists.txt
@@ -6,7 +6,6 @@
 include_directories(
     ${EIGEN3_INCLUDE_DIR})
 
-
 add_executable(musly
     tools.cpp
     fileiterator.cpp
@@ -16,5 +15,14 @@ add_executable(musly
 
 target_link_libraries(musly
     libmusly)
+
+target_compile_definitions(musly PRIVATE
+    BUILD_STATIC MUSLY_BUILDING_STATIC)
+
+if(WIN32)
+    target_link_libraries(musly
+        getopt_windows
+        dirent_windows)
+endif()
 
 install(TARGETS musly DESTINATION bin)

--- a/musly/collectionfile.cpp
+++ b/musly/collectionfile.cpp
@@ -63,9 +63,9 @@ collection_file::exists()
 
 
 bool
-collection_file::write_header(const std::string& method)
+collection_file::write_header(const std::string& meth)
 {
-    fwritestr(fid, header+dash+version+dash+method);
+    fwritestr(fid, header+dash+version+dash+meth);
 
     return true;
 }

--- a/musly/collectionfile.h
+++ b/musly/collectionfile.h
@@ -42,7 +42,7 @@ public:
 
     bool
     write_header(
-            const std::string& method);
+            const std::string& meth);
 
     bool
     read_header();

--- a/musly/fileiterator.cpp
+++ b/musly/fileiterator.cpp
@@ -10,7 +10,11 @@
  */
 
 
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>

--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -234,7 +234,7 @@ tracks_initialize(
     if (trackids.size() <= 1000) {
         // use all available tracks
         ret = musly_jukebox_setmusicstyle(mj, tracks.data(),
-                tracks.size());
+                static_cast<int>(tracks.size()));
     }
     else {
         // use a random subset of 1000 tracks
@@ -248,7 +248,7 @@ tracks_initialize(
 
     // add the tracks to the jukebox
     ret = musly_jukebox_addtracks(mj, tracks.data(), trackids.data(),
-            tracks.size(), true);
+            static_cast<int>(tracks.size()), true);
     if (ret != 0) {
         return false;
     }
@@ -319,7 +319,7 @@ write_mirex_full(
     for (int i = 0; i < (int)tracks.size(); i++) {
         int ret = musly_jukebox_similarity(mj, tracks[i], i,
                 tracks.data(), alltrackids.data(),
-                tracks.size(), similarities.data());
+                static_cast<int>(tracks.size()), similarities.data());
         if (ret != 0) {
             fill(similarities.begin(), similarities.end(),
                     std::numeric_limits<float>::max());
@@ -383,7 +383,7 @@ compute_similarity(
         similarities.resize(alltracks.size());
         int ret = musly_jukebox_similarity(mj,
                 alltracks[seed], seed, alltracks.data(),
-                alltrackids.data(), alltrackids.size(), similarities.data());
+                alltrackids.data(), static_cast<int>(alltrackids.size()), similarities.data());
         if (ret != 0) {
             return knn_sim;
         }
@@ -398,7 +398,7 @@ compute_similarity(
         similarities.resize(guess_ids.size());
         int ret = musly_jukebox_similarity(mj,
                 alltracks[seed], seed, guess_tracks.data(),
-                guess_ids.data(), guess_ids.size(), similarities.data());
+                guess_ids.data(), static_cast<int>(guess_ids.size()), similarities.data());
         if (ret != 0) {
             return knn_sim;
         }
@@ -849,7 +849,8 @@ main(int argc, char *argv[])
 
             std::cout << "Evaluating collection..." << std::endl;
             Eigen::MatrixXi genre_confusion = evaluate_collection(tracks,
-                    genres, genre_ids.size(), artists, artist_ids.size(), k);
+                    genres, static_cast<int>(genre_ids.size()), artists,
+                    static_cast<int>(artist_ids.size()), k);
 
             std::cout << "Genre Confusion matrix:" << std::endl;
             std::cout << genre_confusion << std::endl;
@@ -902,7 +903,7 @@ main(int argc, char *argv[])
             for (int i = 0; i < (int)trackids.size(); i++) {
                 trackids[i] = i;
             }
-            musly_trackid seed = std::distance(tracks_files.begin(), it);
+            musly_trackid seed = static_cast<int>(std::distance(tracks_files.begin(), it));
             std::string pl = compute_playlist(tracks, trackids, tracks_files,
                     seed, k);
             if (pl == "") {

--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -533,7 +533,7 @@ evaluate_collection(
         std::vector<int>& genres,
         int num_genres,
         std::vector<int>& artists,
-        int num_artists,
+        int /*num_artists*/,
         int k)
 {
     Eigen::MatrixXi genre_confusion =

--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -361,7 +361,7 @@ struct similarity_comp {
 
 std::vector<similarity_knn>
 compute_similarity(
-        musly_jukebox* mj,
+        musly_jukebox* local_mj,
         int k,
         std::vector<int>& artists,
         musly_trackid seed,
@@ -370,7 +370,7 @@ compute_similarity(
 {
     int guess_len = std::max(k, (int)(alltracks.size()*0.1));
     std::vector<musly_trackid> guess_ids(guess_len);
-    guess_len = musly_jukebox_guessneighbors(mj, seed,
+    guess_len = musly_jukebox_guessneighbors(local_mj, seed,
             guess_ids.data(), guess_len);
     guess_ids.resize(std::max(guess_len, 0));
 
@@ -381,7 +381,7 @@ compute_similarity(
     // need to compute the full similarity
     if (guess_len <= 0) {
         similarities.resize(alltracks.size());
-        int ret = musly_jukebox_similarity(mj,
+        int ret = musly_jukebox_similarity(local_mj,
                 alltracks[seed], seed, alltracks.data(),
                 alltrackids.data(), static_cast<int>(alltrackids.size()), similarities.data());
         if (ret != 0) {
@@ -396,7 +396,7 @@ compute_similarity(
            guess_tracks[i] = alltracks[guess_ids[i]];
         }
         similarities.resize(guess_ids.size());
-        int ret = musly_jukebox_similarity(mj,
+        int ret = musly_jukebox_similarity(local_mj,
                 alltracks[seed], seed, guess_tracks.data(),
                 guess_ids.data(), static_cast<int>(guess_ids.size()), similarities.data());
         if (ret != 0) {
@@ -481,9 +481,9 @@ write_mirex_sparse(
 #endif
         // write to file
         f << tracks_files[i];
-        for (int i = 0; i < k; i++) {
-            int j = track_idx[i].first;
-            f << "\t" << tracks_files[j] << "," << track_idx[i].second;
+        for (int l = 0; l < k; l++) {
+            int j = track_idx[l].first;
+            f << "\t" << tracks_files[j] << "," << track_idx[l].second;
         }
         f << std::endl;
 #ifdef _OPENMP

--- a/musly/programoptions.cpp
+++ b/musly/programoptions.cpp
@@ -47,7 +47,6 @@ programoptions::programoptions(int argc, char *argv[],
         all_methods += "," + methods[i];
     }
 
-    opterr = 0;
     while (1) {
 
         int c = getopt(argc, argv, "v:ihc:Jj:a:x:Ee:f:Nn:k:ldm:s:p:");

--- a/musly/programoptions.cpp
+++ b/musly/programoptions.cpp
@@ -9,7 +9,11 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <unistd.h>
+#ifdef _WIN32
+    #include <io.h>
+#else
+    #include <unistd.h>
+#endif
 #include <getopt.h>
 #include <iostream>
 #include <sstream>

--- a/musly/programoptions.cpp
+++ b/musly/programoptions.cpp
@@ -60,7 +60,7 @@ programoptions::programoptions(int argc, char *argv[],
             if (action.length() != 0) {
                 action = "error";
             } else {
-                action = tolower(c);
+                action = static_cast<char>(tolower(c));
             }
             break;
 

--- a/musly/tools.cpp
+++ b/musly/tools.cpp
@@ -9,6 +9,8 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <algorithm>
+
 #include "tools.h"
 
 std::string

--- a/musly/tools.cpp
+++ b/musly/tools.cpp
@@ -43,7 +43,7 @@ fwritestr(
 {
     if (fwrite(str.c_str(), sizeof(char), str.length(), fid) == str.length()) {
         if (fputc(0, fid) == 0) {
-            return str.length();
+            return static_cast<int>(str.length());
         } else {
             return -1;
         }
@@ -111,7 +111,7 @@ field_from_strings(
 {
     int prefix_len = 0;
     if (fidx < 0) {
-        prefix_len = longest_common_prefix(strings).length();
+        prefix_len = static_cast<int>(longest_common_prefix(strings).length());
         fidx = 0;
     }
 


### PR DESCRIPTION
This PR addresses issue #15. It enables building with Visual studio.

(1) It adds a Travis Windows build, so we don't break it again
(2) bumps the Warning level to Wall (gcc/clang) and /W4 (VC++)
(3) compiles with with warnings as errors (Werror and /WX)
(4) Subsequently fixes all compiler warnings that broke the build due to (2) and (3)