### PR TITLE
Run selftest in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ matrix:
 script:
     - mkdir -p build
     - cd build
-    - cmake ..
+    - cmake -DBUILD_TEST=ON ..
     - make -j
+    - ctest -V
 
 addons:
     apt:


### PR DESCRIPTION
As discussed in #45, this adds the compilation and execution of musly's test suite to the Travis build job.