### PR TITLE
Remove unused private fields in resampler class

### DIFF
--- a/libmusly/resampler.cpp
+++ b/libmusly/resampler.cpp
@@ -16,8 +16,6 @@
 namespace musly {
 
 resampler::resampler(int input_rate, int output_rate):
-        input_rate(input_rate),
-        output_rate(output_rate),
         resample_factor((double)output_rate/(double)input_rate)
 {
     libresample = resample_open(1, resample_factor, resample_factor);

--- a/libmusly/resampler.h
+++ b/libmusly/resampler.h
@@ -21,8 +21,6 @@ namespace musly {
 
 class resampler {
 private:
-    int input_rate;
-    int output_rate;
     double resample_factor;
 
     void* libresample;


### PR DESCRIPTION
The `input_rate` and `output_rate` fields are never read inside the class and cannot be read outside the class. Clang warned about that.