### PR TITLE
Use binary or, not logical or to combine flags

### DIFF
--- a/libmusly/decoders/libav.cpp
+++ b/libmusly/decoders/libav.cpp
@@ -296,7 +296,7 @@ libav::decodeto_22050hz_mono_float(
         // fault when trying to access frame->data[i] for i > 0 further below)
         if ((excerpt_start > 0) and (av_seek_frame(fmtx, audio_stream_idx,
                     excerpt_start * st->time_base.den / st->time_base.num,
-                    AVSEEK_FLAG_BACKWARD || AVSEEK_FLAG_ANY) >= 0)) {
+                    AVSEEK_FLAG_BACKWARD | AVSEEK_FLAG_ANY) >= 0)) {
             // skipping went fine: decode only what's needed
             decode_samples = excerpt_length * decx->sample_rate;
             excerpt_start = 0;


### PR DESCRIPTION
Two flags in an `av_seek_frame` call where combined using `||`. Specifically, `AVSEEK_FLAG_BACKWARD || AVSEEK_FLAG_ANY` evaluated to `1 || 4` which gives `1`, and is the same as `AVSEEK_FLAG_BACKWARD` alone. Fixed to use `|` instead. Clang warned about it.