### PR TITLE
Output mode for printing playlists of similar tracks

### DIFF
--- a/musly/main.cpp
+++ b/musly/main.cpp
@@ -503,7 +503,8 @@ compute_playlist(
         std::vector<musly_trackid>& alltrackids,
         std::vector<std::string>& tracks_files,
         musly_trackid seed,
-        int k)
+        int k,
+        std::string outputmode)
 {
     k = std::min(k, (int)alltracks.size());
     std::vector<int> artists_null; // disable artist filtering
@@ -519,7 +520,15 @@ compute_playlist(
     std::ostringstream pl;
     for (int i = 0; i < k; i++) {
         int j = track_idx[i].first;
-        pl << tracks_files[j] << std::endl;
+
+        if (outputmode == "short") {
+            pl << tracks_files[j] << std::endl;
+        } else if (outputmode == "long") {
+            float d = track_idx[i].second;
+
+            pl << "track-id: " << j << ", track-distance: " << d
+                    << ", track-origin: " << tracks_files[j] << std::endl;
+        }
     }
 
     return pl.str();
@@ -903,8 +912,9 @@ main(int argc, char *argv[])
                 trackids[i] = i;
             }
             musly_trackid seed = std::distance(tracks_files.begin(), it);
+            std::string outputmode = po.get_option_str("o");
             std::string pl = compute_playlist(tracks, trackids, tracks_files,
-                    seed, k);
+                    seed, k, outputmode);
             if (pl == "") {
                 std::cerr << "Failed to compute similar tracks for given file."
                         << std::endl;

--- a/musly/programoptions.cpp
+++ b/musly/programoptions.cpp
@@ -22,6 +22,7 @@
 programoptions::programoptions(int argc, char *argv[],
         const std::vector<std::string>& methods) :
         default_collection("collection.musly"),
+        default_outputmode("short"),
         default_k(5),
         default_debuglevel(0),
         action(""),
@@ -36,6 +37,7 @@ programoptions::programoptions(int argc, char *argv[],
     optionstr["k"] = kstr.str();
     optionstr["e"] = "-1";
     optionstr["f"] = "-1";
+    optionstr["o"] = default_outputmode;
 
     // Build a CSV string with all methods available.
     all_methods = methods[0];
@@ -46,7 +48,7 @@ programoptions::programoptions(int argc, char *argv[],
     opterr = 0;
     while (1) {
 
-        int c = getopt(argc, argv, "v:ihc:Jj:a:x:Ee:f:Nn:k:ldm:s:p:");
+        int c = getopt(argc, argv, "v:ihc:Jj:a:x:Ee:f:Nn:k:ldm:s:p:o:");
         if (c == -1) {
             break;
         }
@@ -90,6 +92,7 @@ programoptions::programoptions(int argc, char *argv[],
         case 'c':
         case 'j':
         case 'k':
+        case 'o':
         case 'f':
             if (optarg) {
                 std::string copt;
@@ -177,6 +180,9 @@ cout << "  -k NUM       set number of similar songs per item when computing" << 
      << "               playlists ('-p'), sparse distance matrices ('-s')" << endl
      << "               or when evaluating the collection ('-e')." << endl
      << "               DEFAULT: " << default_k << endl;
+cout << "  -o MODE      Set the output mode when printing a playlist ('-p') of" << endl
+     << "               the most similar tracks. Possible modes: 'short', 'long'." << endl
+     << "               DEFAULT: " << default_outputmode << endl;
 cout << " INITIALIZATION:" << endl;
 cout << "  -n MTH | -N  initialize the collection (set with '-c') using the" << endl
      << "               music similarity method MTH. Available methods:" << endl

--- a/musly/programoptions.h
+++ b/musly/programoptions.h
@@ -21,6 +21,7 @@ private:
 
     std::string all_methods;
     std::string default_collection;
+    std::string default_outputmode;
     int default_k;
     int default_debuglevel;
     std::string action;


### PR DESCRIPTION
Hello! In musly command line tool, I added the ability to change output mode. The new mode allows printing a playlist of similar tracks in a similar way as when listing files from the collection.

Please see an example outputs below:

```
$ musly -p test/2.mp3 # or: musly -o short -p test/2.mp3
[...]
Computing the k=5 most similar tracks to: test/2.mp3
audio/3.mp3
test/1.mp3
test/5.mp3
test/4.mp3

$ musly -o long -p test/2.mp3
[...]
Computing the k=5 most similar tracks to: test/2.mp3
track-id: 3, track-distance: 0.720967, track-origin: test/3.mp3
track-id: 2, track-distance: 0.837826, track-origin: test/1.mp3
track-id: 1, track-distance: 0.910639, track-origin: test/5.mp3
track-id: 4, track-distance: 0.93015, track-origin: test/4.mp3
```